### PR TITLE
Get list exams also by Ladok ID

### DIFF
--- a/backend/api/listAllExams.js
+++ b/backend/api/listAllExams.js
@@ -42,6 +42,15 @@ async function getLadokId(courseId) {
 
 /** Returns a list of scanned exams (i.e. in Windream) given its ladokId */
 async function listScannedExams(courseId, ladokId) {
+  // Try getting exams using the Ladok ID. (new format)
+  const allScannedExams = await tentaApi.examListByLadokId(ladokId);
+
+  if (allScannedExams.length > 0) {
+    return allScannedExams;
+  }
+
+  // If there are no exams with the new format
+  // try finding them using { courseCode, examCode, examDate }
   const aktivitetstillfalle = await ladok
     .getAktivitetstillfalle(ladokId)
     .catch(() => {
@@ -57,7 +66,6 @@ async function listScannedExams(courseId, ladokId) {
 
   const { activities, examDate } = aktivitetstillfalle;
 
-  const allScannedExams = [];
   for (const { courseCode, examCode } of activities) {
     allScannedExams.push(
       // eslint-disable-next-line no-await-in-loop

--- a/backend/api/tentaApiClient.js
+++ b/backend/api/tentaApiClient.js
@@ -15,6 +15,52 @@ async function getVersion() {
   return body;
 }
 
+async function examListByLadokId(ladokId) {
+  log.info(`Getting exams for Ladok ID ${ladokId}`);
+
+  const { body } = await client("windream/search/documents/false", {
+    method: "POST",
+    json: {
+      searchIndiceses: [
+        {
+          index: "e_ladokid",
+          value: ladokId,
+          useWildcard: false,
+        },
+      ],
+      includeDocumentIndicesesInResponse: true,
+      includeSystemIndicesesInResponse: false,
+      useDatesInSearch: false,
+    },
+    responseType: "json",
+  });
+
+  if (!body.documentSearchResults) {
+    log.info(`No exams found for ladok ID ${ladokId}`);
+    return [];
+  }
+
+  const list = [];
+
+  for (const result of body.documentSearchResults) {
+    // Helper function to get the value of the attribute called "index"
+    // we have written it because they are in an array instead of an object
+    const getValue = (index) =>
+      result.documentIndiceses.find((di) => di.index === index)?.value;
+
+    list.push({
+      fileId: result.fileId,
+      student: {
+        id: getValue("s_uid"),
+        firstName: getValue("s_firstname"),
+        lastName: getValue("s_lastname"),
+      },
+    });
+  }
+
+  return list;
+}
+
 /** Get a list of all exam files for a given exam */
 async function examList({ courseCode, examDate, examCode }) {
   log.info(`Getting exams for ${courseCode} ${examDate} ${examCode}`);
@@ -95,6 +141,7 @@ async function downloadExam(fileId) {
 
 module.exports = {
   examList,
+  examListByLadokId,
   downloadExam,
   getVersion,
 };


### PR DESCRIPTION
With this PR, backend tries to get the exam list from TentaAPI using the Ladok ID instead of `{ courseCode, examCode, examDate }`. If that doesn't return any results, tries the other solution