### PR TITLE
Remove duplicates

### DIFF
--- a/backend/api/ladokApiClient.js
+++ b/backend/api/ladokApiClient.js
@@ -27,6 +27,15 @@ async function getAktivitetstillfalle(ladokId) {
   }));
 
   return {
+    // When fetching Ladok asking which examCode-courseCode are associated
+    // with one "aktivitetstillfälle", we might get the same pair of
+    // courseCode-examCode. This is because the same course can have multiple
+    // versions and in those cases every version is returned as a separate
+    // element. Example:
+    //   Try to GET https://api.integrationstest.ladok.se/resultat/aktivitetstillfalle/0aa3c265-9dce-11eb-863b-62bcffd242dd
+    //   and look at "Kopplingar" in the body response
+    // However, from our perspective all versions are identical so we can just
+    // remove all duplicates safely.
     activities: removeDuplicates(activities),
     examDate: body.Datumperiod.Startdatum,
   };

--- a/backend/api/ladokApiClient.js
+++ b/backend/api/ladokApiClient.js
@@ -12,8 +12,20 @@ const ladokGot = got.extend({
   },
 });
 
-function removeDuplicates(arr) {
-  return Array.from(new Set(arr.map(JSON.stringify))).map(JSON.parse);
+/**
+ * Deduplicate an array of {examCode, courseCode} objects
+ * @param {Object[]} arr
+ * @param {string} arr[].examCode
+ * @param {string} arr[].courseCode
+ * @returns
+ */
+function deduplicate(arr) {
+  return arr.filter(
+    (e1) =>
+      !arr.find(
+        (e2) => e1.courseCode === e2.courseCode && e1.examCode === e2.examCode
+      )
+  );
 }
 
 async function getAktivitetstillfalle(ladokId) {
@@ -36,7 +48,7 @@ async function getAktivitetstillfalle(ladokId) {
     //   and look at "Kopplingar" in the body response
     // However, from our perspective all versions are identical so we can just
     // remove all duplicates safely.
-    activities: removeDuplicates(activities),
+    activities: deduplicate(activities),
     examDate: body.Datumperiod.Startdatum,
   };
 }

--- a/backend/api/ladokApiClient.js
+++ b/backend/api/ladokApiClient.js
@@ -12,16 +12,22 @@ const ladokGot = got.extend({
   },
 });
 
+function removeDuplicates(arr) {
+  return Array.from(new Set(arr.map(JSON.stringify))).map(JSON.parse);
+}
+
 async function getAktivitetstillfalle(ladokId) {
   log.info(`Getting information for aktivitetstillfälle ${ladokId}`);
   const res = ladokGot.get(`resultat/aktivitetstillfalle/${ladokId}`);
   const body = await res.json();
 
+  const activities = body.Kopplingar.map((k) => ({
+    examCode: k.Aktivitet.Utbildningskod,
+    courseCode: k.Kursinstans.Utbildningskod,
+  }));
+
   return {
-    activities: body.Kopplingar.map((k) => ({
-      examCode: k.Aktivitet.Utbildningskod,
-      courseCode: k.Kursinstans.Utbildningskod,
-    })),
+    activities: removeDuplicates(activities),
     examDate: body.Datumperiod.Startdatum,
   };
 }


### PR DESCRIPTION
This PR eliminates duplicated `courseCode, examCode` that sometimes are returned by the function `getAktivitetstillfalle`.