### PR TITLE
Handle case where getStatusFromQueue returns null

### DIFF
--- a/backend/api/router.js
+++ b/backend/api/router.js
@@ -130,7 +130,7 @@ router.get("/courses/:id/import/status", async (req, res) => {
 // Start the import process
 router.post("/courses/:id/import/start", async (req, res, next) => {
   const courseId = req.params.id;
-  const { status } = await getStatusFromQueue(courseId);
+  const { status } = (await getStatusFromQueue(courseId)) || {};
 
   if (!Array.isArray(req.body)) {
     return next(


### PR DESCRIPTION
Fixes (probably non-fatal) error:
[13:45:22.339] FATAL: Reject: TypeError: Cannot destructure property 'status' of '(intermediate value)' as it is null.
TypeError: Cannot destructure property 'status' of '(intermediate value)' as it is null.
at /Users/jhsware/node/KTH/scanned-exams/backend/api/router.js:132:13
at runMicrotasks (<anonymous>)
at processTicksAndRejections (internal/process/task_queues.js:95:5)