### PR TITLE
Important fix of issue that prevented showing "done" when done

### DIFF
--- a/frontend/src/features/import-exams/steps/PrepareImport.js
+++ b/frontend/src/features/import-exams/steps/PrepareImport.js
@@ -29,12 +29,11 @@ export default function PrepareImport({ onGoTo, courseId }) {
 
   // Get exams available to import
   const queryExams = useCourseExams(courseId);
-  const { data: exams = { result: [] }, isLoading: examsLoading } = queryExams;
+  const { data = {}, isLoading: examsLoading } = queryExams;
+  const { result: exams = [] } = data;
 
-  const examsToImport =
-    exams.result.filter((exam) => exam.status === "new") || [];
-  const examsWithError =
-    exams.result.filter((exam) => exam.status === "error") || [];
+  const examsToImport = exams.filter((exam) => exam.status === "new") || [];
+  const examsWithError = exams.filter((exam) => exam.status === "error") || [];
 
   const allExamsToImportOnNextTry = [...examsToImport, ...examsWithError];
 

--- a/frontend/src/features/import-exams/steps/ResolveIssues.js
+++ b/frontend/src/features/import-exams/steps/ResolveIssues.js
@@ -82,9 +82,8 @@ export default function ResolveIssues({ onGoTo, courseId }) {
       <div className="max-w-2xl">
         <H2>Resolve in progress...</H2>
         <p>
-          Fixing issues with your latest import. This adds missing students and
-          also attempts to fix other import errors. Please stay on this page
-          during this process.
+          Re-importing exams with issues. Please stay on this page during this
+          process.
         </p>
         <div className="mt-8">
           <ImportQueueProgressBar
@@ -123,12 +122,12 @@ export default function ResolveIssues({ onGoTo, courseId }) {
               assignment even if not all of them where succesfully imported.
             </P>
             <P>
-              <b>Exams marked with "missing student"</b> can be fixed by
-              clicking the button "Fix missing students!".
+              <b>Exams marked with &quot;missing student&quot;</b> can be fixed
+              by clicking the button &quot;Fix missing students!&quot;.
             </P>
             <P>
-              <b>Exams marked with other errors</b> might need further
-              investigation. Contact IT-support or click "Re-import rows..." if you
+              <b>Exams marked as unhandled</b> might need further investigation.
+              Contact IT-support or click &quot;Re-import rows...&quot; if you
               believe the issue has been resolved.
             </P>
           </div>


### PR DESCRIPTION
Poor choice of naming of variable caused bug when attempting to redirect to verify page showing "done" message.

Also fixes text during  re-import because it is used both for adding students and performing a simple re-import.