### PR TITLE
Support old formats

### DIFF
--- a/backend/api/importQueue.js
+++ b/backend/api/importQueue.js
@@ -160,7 +160,8 @@ async function resetQueueForImport(courseId) {
     });
   } catch (err) {
     log.warn(
-      "resetQueueForImport failet with error. If this happens once in isolation it is okay, this method is called every time we start an import.");
+      "resetQueueForImport failet with error. If this happens once in isolation it is okay, this method is called every time we start an import."
+    );
     log.error(err);
     throw new Error("Error removing finished entries");
   }

--- a/backend/api/ladokApiClient.js
+++ b/backend/api/ladokApiClient.js
@@ -13,7 +13,7 @@ const ladokGot = got.extend({
 });
 
 async function getAktivitetstillfalle(ladokId) {
-  log.info(`Getting information for aktivitetstillfälle ${ladokId}`);
+  log.debug(`Getting information for aktivitetstillfälle ${ladokId}`);
   const res = ladokGot.get(`resultat/aktivitetstillfalle/${ladokId}`);
   const body = await res.json();
 

--- a/backend/api/tentaApiClient.js
+++ b/backend/api/tentaApiClient.js
@@ -62,7 +62,7 @@ async function examListByLadokId(ladokId) {
 }
 
 /** Get a list of all exam files for a given exam */
-async function examList({ courseCode, examDate, examCode }) {
+async function examListByDate({ courseCode, examDate, examCode }) {
   log.debug(
     `Getting exams with the "old format" ${courseCode} ${examDate} ${examCode}`
   );
@@ -150,7 +150,7 @@ async function downloadExam(fileId) {
 }
 
 module.exports = {
-  examList,
+  examListByDate,
   examListByLadokId,
   downloadExam,
   getVersion,

--- a/backend/api/tentaApiClient.js
+++ b/backend/api/tentaApiClient.js
@@ -16,7 +16,7 @@ async function getVersion() {
 }
 
 async function examListByLadokId(ladokId) {
-  log.info(`Getting exams for Ladok ID ${ladokId}`);
+  log.debug(`Getting exams for Ladok ID ${ladokId}`);
 
   const { body } = await client("windream/search/documents/false", {
     method: "POST",
@@ -36,7 +36,7 @@ async function examListByLadokId(ladokId) {
   });
 
   if (!body.documentSearchResults) {
-    log.info(`No exams found for ladok ID ${ladokId}`);
+    log.info(`No exams found with the "new format" e_ladokid=${ladokId}`);
     return [];
   }
 
@@ -63,7 +63,9 @@ async function examListByLadokId(ladokId) {
 
 /** Get a list of all exam files for a given exam */
 async function examList({ courseCode, examDate, examCode }) {
-  log.debug(`Getting exams for ${courseCode} ${examDate} ${examCode}`);
+  log.debug(
+    `Getting exams with the "old format" ${courseCode} ${examDate} ${examCode}`
+  );
   const { body } = await client("windream/search/documents/false", {
     method: "POST",
     json: {

--- a/backend/api/tentaApiClient.js
+++ b/backend/api/tentaApiClient.js
@@ -36,7 +36,7 @@ async function examListByLadokId(ladokId) {
   });
 
   if (!body.documentSearchResults) {
-    log.info(`No exams found with the "new format" e_ladokid=${ladokId}`);
+    log.debug(`No exams found with the "new format" e_ladokid=${ladokId}`);
     return [];
   }
 


### PR DESCRIPTION
This PR supports exams that have both the old and new format instead of supporting either one or the other.

It also changes the log messages so we can have some control about when the old format is no longer used