### PR TITLE
Use a template for homepage and assignment

### DIFF
--- a/backend/api/canvasApiClient.js
+++ b/backend/api/canvasApiClient.js
@@ -10,6 +10,19 @@ const canvas = new Canvas(
   process.env.CANVAS_API_ADMIN_TOKEN
 );
 
+/**
+ * These endpoints have the content used as a template when creating the
+ * homepage and assignment.
+ */
+const TEMPLATES = {
+  assignment: {
+    en: "courses/33450/assignments/178066",
+  },
+  homepage: {
+    en: "courses/33450/pages/151311",
+  },
+};
+
 /** Get data from one canvas course */
 async function getCourse(courseId) {
   const { body } = await canvas.get(`courses/${courseId}`);
@@ -18,15 +31,14 @@ async function getCourse(courseId) {
 }
 
 /** Creates a "good-looking" homepage in Canvas */
-async function createHomepage(courseId) {
+async function createHomepage(courseId, language = "en") {
+  const { body: template } = await canvas.get(TEMPLATES.homepage[language]);
+
   await canvas.requestUrl(`courses/${courseId}/front_page`, "PUT", {
     wiki_page: {
       // To make this page, use the Rich Content Editor in Canvas (https://kth.test.instructure.com/courses/30347/pages/welcome-to-the-exam/edit)
-      // Then copy the HTML code:
-      body: `<p>Welcome to the Canvas page for the exam results</p>
-      <p>This course will be used to grade your exams digitally. This means that, after your exams are scanned, they will be uploaded in this Canvas course</p>
-      <p>&nbsp;</p>
-      <p>Once your exam has been graded, you will be able to see the grades and teachers feedback under "Grades".</p>`,
+      body: template.body,
+      title: template.title,
     },
   });
   return canvas.requestUrl(`courses/${courseId}`, "PUT", {
@@ -109,15 +121,15 @@ async function getAssignmentSubmissions(courseId, assignmentId) {
     .toArray();
 }
 
-async function createAssignment(courseId, ladokId) {
+async function createAssignment(courseId, ladokId, language = "en") {
   const examination = await getAktivitetstillfalle(ladokId);
+  const { body: template } = await canvas.get(TEMPLATES.assignment[language]);
 
   return canvas
     .requestUrl(`courses/${courseId}/assignments`, "POST", {
       assignment: {
-        name: "Scanned exams",
-        description:
-          'This is an assignment created automatically by importing scanned exams to Canvas. The grade posting policy is set to "Manual" which makes it possible to grade all submissions before publishing the student feedback for all students at once.',
+        name: template.name,
+        description: template.description,
         submission_types: ["online_upload"],
         allowed_extensions: ["pdf"],
         // TODO: save only the "Ladok UID" because `examination.courseCode` and


### PR DESCRIPTION
This endpoint replaces the hardcoded values for assignment and homepage. Instead it takes the content from a given canvas course.

---

Note: this PR does **NOT** work in Canvas TEST until Canvas has copied the values correctly. Reason is that course ID "33450" is a different course in Canvas production and in test