### PR TITLE
Pass courseId to logging for traceability

### DIFF
--- a/backend/api/error.js
+++ b/backend/api/error.js
@@ -204,8 +204,15 @@ function _formatErrorMsg(name, type, message) {
  */
 function errorHandler(err, req, res, next) {
   if (err instanceof AuthError) {
-    // Simple auth errors
-    log.error(err);
+    switch (err.type) {
+      case "permission_denied":
+        // This is common and only used for debugging
+        log.debug(err);
+        break;
+      default:
+        // All other auth errors
+        log.error(err);
+    }
     // Add error details if provided for debugging
     if (err.details) log.debug(err.details);
   } else if (err instanceof EndpointError) {

--- a/backend/api/importQueue/index.js
+++ b/backend/api/importQueue/index.js
@@ -379,7 +379,7 @@ async function updateStatusOfEntryInQueue(entry, status, errorDetails) {
         throw new ImportError({
           type: "not_found",
           statusCode: 404,
-          message: `Entry ${entry.fileId} in import queue not found.`,
+          message: `Entry ${entry.fileId} in import queue not found.`,
         });
       }
 

--- a/backend/api/importQueue/index.js
+++ b/backend/api/importQueue/index.js
@@ -153,7 +153,7 @@ async function getEntriesFromQueue(courseId) {
     return entries.map((entry) => new QueueEntry(entry));
   } catch (err) {
     // TODO: Handle errors
-    log.child({ courseId }).error({ err });
+    log.error({ err });
     throw ImportError({
       err,
     });
@@ -189,7 +189,7 @@ async function resetQueueForImport(courseId) {
       },
     });
   } catch (err) {
-    log.child({ courseId }).error({ err });
+    log.error({ err });
     throw new ImportError({
       type: "delete_error",
       statusCode: 420,
@@ -283,7 +283,7 @@ async function getStatusFromQueue(courseId) {
     });
   } catch (err) {
     // TODO: Handle errors
-    log.child({ courseId }).error({ err });
+    log.error({ err });
     throw err;
   }
 }
@@ -326,7 +326,7 @@ async function updateStudentOfEntryInQueue(
 
     return typedEntry;
   } catch (err) {
-    log.child({ courseId: entry?.courseId }).error({ err });
+    log.error({ err });
     throw err;
   }
 }
@@ -390,7 +390,7 @@ async function updateStatusOfEntryInQueue(entry, status, errorDetails) {
     return null;
   } catch (err) {
     // TODO: Handle errors
-    log.child({ courseId: entry?.courseId }).error({ err });
+    log.error({ err });
     throw err;
   }
 }
@@ -419,7 +419,7 @@ async function removeEntryFromQueue(entry) {
       fileId: entry.fileId,
     });
   } catch (err) {
-    log.child({ courseId: entry?.courseId }).error({ err });
+    log.error({ err });
     throw new ImportError({
       type: "delete_error",
       statusCode: 420,

--- a/backend/api/importQueue/index.js
+++ b/backend/api/importQueue/index.js
@@ -153,7 +153,7 @@ async function getEntriesFromQueue(courseId) {
     return entries.map((entry) => new QueueEntry(entry));
   } catch (err) {
     // TODO: Handle errors
-    log.error({ err });
+    log.child({ courseId }).error({ err });
     throw ImportError({
       err,
     });
@@ -189,7 +189,7 @@ async function resetQueueForImport(courseId) {
       },
     });
   } catch (err) {
-    log.error({ err });
+    log.child({ courseId }).error({ err });
     throw new ImportError({
       type: "delete_error",
       statusCode: 420,
@@ -283,7 +283,7 @@ async function getStatusFromQueue(courseId) {
     });
   } catch (err) {
     // TODO: Handle errors
-    log.error({ err });
+    log.child({ courseId }).error({ err });
     throw err;
   }
 }
@@ -326,7 +326,7 @@ async function updateStudentOfEntryInQueue(
 
     return typedEntry;
   } catch (err) {
-    log.error({ err });
+    log.child({ courseId: entry?.courseId }).error({ err });
     throw err;
   }
 }
@@ -390,7 +390,7 @@ async function updateStatusOfEntryInQueue(entry, status, errorDetails) {
     return null;
   } catch (err) {
     // TODO: Handle errors
-    log.error({ err });
+    log.child({ courseId: entry?.courseId }).error({ err });
     throw err;
   }
 }
@@ -419,7 +419,7 @@ async function removeEntryFromQueue(entry) {
       fileId: entry.fileId,
     });
   } catch (err) {
-    log.error({ err });
+    log.child({ courseId: entry?.courseId }).error({ err });
     throw new ImportError({
       type: "delete_error",
       statusCode: 420,

--- a/backend/server.js
+++ b/backend/server.js
@@ -69,9 +69,14 @@ server.use(
 
 server.use(log.middleware);
 server.use((req, res, next) => {
+  // Get courseId from path if available
+  const courseId = req.path.startsWith("/scanned-exams/api/courses")
+    ? req.path.split("/")[4]
+    : undefined;
   log.child(
     {
       session_id: req.session.id.slice(0, 6),
+      course_id: courseId,
     },
     next
   );
@@ -126,7 +131,7 @@ server.post("/scanned-exams", async (req, res) => {
   }
 });
 server.use("/scanned-exams/auth", authRouter);
-server.use("/scanned-exams/api", apiRouter);
+server.use("/scanned-exams/api", apiRouter); // NOTE: If you change this route mapping, please update the logging middleware
 server.get("/scanned-exams/app", async (req, res) => {
   try {
     const html = await fs.promises.readFile(


### PR DESCRIPTION
Needs testing, but I want feedback on the concept.

1. I updated the general middleware logger by adding course id from path if calling /scanned-exams/api/courses/...
2. I added course id to every logging statement in processQueueEntry because it runs in the background