### PR TITLE
Missing submissions when exams are scanned in different batches

### DIFF
--- a/backend/src/api/endpointHandlers/listAllExams.ts
+++ b/backend/src/api/endpointHandlers/listAllExams.ts
@@ -64,9 +64,9 @@ async function listStudentsWithExamsInCanvas(courseId, ladokId) {
     assignment.id
   );
 
-  // Filter-out submissions without exams or without KTH ID
+  // Select only online_upload submissions
   return submissions
-    .filter((s) => s.workflow_state !== "unsubmitted" || !s.user?.sis_user_id)
+    .filter((s) => s.submission_type === "online_upload")
     .map((submission) => submission.user?.sis_user_id);
 }
 


### PR DESCRIPTION
"workflow_state" can be set to "graded" even when there is no submission. 

The submissions were scanned in different batches and it is possible that SpeedGrader (or teacher) has marked missing submissions as "graded" even though they are waiting to be imported. This prevented the app from importing them once they were available.

To solve this I am changing the filter criteria for existing submissions to `submission_type === "online_upload"` thus overriding submissions that have been marked graded even though they hadn't been imported yet.