### PR TITLE
Canvas User API Client

### DIFF
--- a/backend/src/api/externalApis/canvasUserApiClient.ts
+++ b/backend/src/api/externalApis/canvasUserApiClient.ts
@@ -1,0 +1,32 @@
+/**
+ * Instantiable Canvas API Client
+ *
+ * Instead of using a fixed API Token, this client is built with an API Token.
+ * That way you can make queries on behalf of that token instead of an "admin"
+ * token.
+ *
+ * It also defines Types for the responses from Canvas so they can be
+ * more predictable
+ */
+import Canvas from "@kth/canvas-api";
+
+interface Enrollment {
+  role_id: number;
+}
+
+export default class CanvasUserApiClient {
+  client: Canvas;
+
+  constructor(apiToken: string) {
+    this.client = new Canvas(process.env.CANVAS_API_URL, apiToken);
+  }
+
+  /** Get which roles have the current user in a given course */
+  async getRoles(courseId: string) {
+    const enrollments = await this.client
+      .listItems<Enrollment>(`courses/${courseId}/enrollments`)
+      .toArray();
+
+    return enrollments.map((e) => e.role_id);
+  }
+}

--- a/backend/src/api/externalApis/canvasUserApiClient.ts
+++ b/backend/src/api/externalApis/canvasUserApiClient.ts
@@ -24,7 +24,7 @@ export default class CanvasUserApiClient {
   /** Get which roles have the current user in a given course */
   async getRoles(courseId: string) {
     const enrollments = await this.client
-      .listItems<Enrollment>(`courses/${courseId}/enrollments`)
+      .listItems<Enrollment>(`courses/${courseId}/enrollments?user_id=self`)
       .toArray();
 
     return enrollments.map((e) => e.role_id);

--- a/backend/src/api/externalApis/canvasUserApiClient.ts
+++ b/backend/src/api/externalApis/canvasUserApiClient.ts
@@ -10,8 +10,12 @@
  */
 import Canvas from "@kth/canvas-api";
 
-interface Enrollment {
+interface IRole {
   role_id: number;
+}
+
+interface ICourse {
+  enrollments: IRole[];
 }
 
 export default class CanvasUserApiClient {
@@ -23,10 +27,9 @@ export default class CanvasUserApiClient {
 
   /** Get which roles have the current user in a given course */
   async getRoles(courseId: string) {
-    const enrollments = await this.client
-      .listItems<Enrollment>(`courses/${courseId}/enrollments?user_id=self`)
-      .toArray();
+    const { body: course } = await this.client
+      .get<ICourse>(`courses/${courseId}`);
 
-    return enrollments.map((e) => e.role_id);
+    return course.enrollments?.map((r) => r.role_id);
   }
 }


### PR DESCRIPTION
This PR introduces a new Canvas API Client. Instead of using the same admin token for all requests, this new client uses a "user token", i.e. a token obtained via oauth.

The goal would be to continue growing this new client so all requests to the Canvas API are performed on behalf of the user rather than on behalf of admin.

This PR also adds Typescript types:

- Type definition for "Enrollment" in the new Canvas API Client (it defines only the fields that are going to be used)
- Type definition for "CanvasTokenSet" in the oauth in an attempt of standarize what is included in the response from Canvas