### PR TITLE
Use scoped developer key

### DIFF
--- a/backend/src/auth/router.ts
+++ b/backend/src/auth/router.ts
@@ -41,7 +41,7 @@ router.post("/", (req, res) => {
   const state = generators.state();
   const url = client.authorizationUrl({
     state,
-    scope: "url:GET|/api/v1/courses/:course_id/enrollments",
+    scope: "url:GET|/api/v1/courses/:course_id",
   });
 
   req.session.temporalCourseId = req.body.courseId;

--- a/backend/src/auth/router.ts
+++ b/backend/src/auth/router.ts
@@ -41,7 +41,7 @@ router.post("/", (req, res) => {
   const state = generators.state();
   const url = client.authorizationUrl({
     state,
-    scope: "url:GET|/api/v1/courses/:course_id",
+    scope: "url:GET|/api/v1/courses/:id",
   });
 
   req.session.temporalCourseId = req.body.courseId;

--- a/backend/src/auth/router.ts
+++ b/backend/src/auth/router.ts
@@ -41,6 +41,7 @@ router.post("/", (req, res) => {
   const state = generators.state();
   const url = client.authorizationUrl({
     state,
+    scope: "url:GET|/api/v1/courses/:course_id/enrollments",
   });
 
   req.session.temporalCourseId = req.body.courseId;


### PR DESCRIPTION
This PR uses a scopes when requesting access token which increases security if leaked.

NOTE: this change only takes effect if the Developer Key is scoped. To do it:

- Go to https://kth.beta.instructure.com/accounts/1/developer_keys#, search for the right Developer Key (localdev, stage or production) and set the scope "url:GET|/api/v1/courses/:id"