### PR TITLE
We now support re-importing exams when file deleted

### DIFF
--- a/backend/src/api/endpointHandlers/listAllExams.ts
+++ b/backend/src/api/endpointHandlers/listAllExams.ts
@@ -77,7 +77,7 @@ async function listStudentsWithExamsInCanvas(courseId, ladokId) {
     .filter((s) => s.attachments.reduce((val, next) => next.filename !== "file_removed.pdf" ? val + 1 : val, 0))
     // Remove submissions witout KTH ID
     .filter((s) => s.user?.sis_user_id)
-    .map(s => s.user.user.sis_user_id);
+    .map(s => s.user.sis_user_id);
 }
 
 function calcNewSummary({ ...summaryProps }: TErrorSummary, status: string, error: any) : TErrorSummary {

--- a/backend/src/api/endpointHandlers/listAllExams.ts
+++ b/backend/src/api/endpointHandlers/listAllExams.ts
@@ -77,6 +77,7 @@ async function listStudentsWithExamsInCanvas(courseId, ladokId) {
     .filter((s) => s.attachments.reduce((val, next) => next.filename !== "file_removed.pdf" ? val + 1 : val, 0))
     // Remove submissions witout KTH ID
     .filter((s) => s.user?.sis_user_id)
+    .map(s => s.user.user.sis_user_id);
 }
 
 function calcNewSummary({ ...summaryProps }: TErrorSummary, status: string, error: any) : TErrorSummary {

--- a/backend/src/api/endpointHandlers/listAllExams.ts
+++ b/backend/src/api/endpointHandlers/listAllExams.ts
@@ -64,10 +64,19 @@ async function listStudentsWithExamsInCanvas(courseId, ladokId) {
     assignment.id
   );
 
-  // Select only online_upload submissions
+  // Filter-out submissions without exams
   return submissions
-    .filter((s) => s.submission_type === "online_upload")
-    .map((submission) => submission.user?.sis_user_id);
+    .filter((s) => (
+        s.workflow_state !== "unsubmitted"
+        && Array.isArray(s.attachments)
+        && s.attachments.length > 0
+      )
+    )
+    // Remove submissions with only deleted files. They are marked with { filename: 'file_removed.pdf' } by SpeedGrader/Canvas
+    // 0 - remove from list, >= 1 - keep in list
+    .filter((s) => s.attachments.reduce((val, next) => next.filename !== "file_removed.pdf" ? val + 1 : val, 0))
+    // Remove submissions witout KTH ID
+    .filter((s) => s.user?.sis_user_id)
 }
 
 function calcNewSummary({ ...summaryProps }: TErrorSummary, status: string, error: any) : TErrorSummary {

--- a/backend/src/api/endpointHandlers/listAllExams.ts
+++ b/backend/src/api/endpointHandlers/listAllExams.ts
@@ -40,7 +40,7 @@ async function listScannedExams(courseId, ladokId) {
 /**
  * Returns a list of students (KTH IDs) that has an exam in Canvas
  */
-async function listStudentsWithExamsInCanvas(courseId, ladokId) {
+async function listStudentsWithExamsInCanvas(courseId, ladokId) : Promise<String[]> {
   const assignment = await canvasApi
     .getValidAssignment(courseId, ladokId)
     .then((result) => {
@@ -66,18 +66,33 @@ async function listStudentsWithExamsInCanvas(courseId, ladokId) {
 
   // Filter-out submissions without exams
   return submissions
-    .filter((s) => (
-        s.workflow_state !== "unsubmitted"
-        && Array.isArray(s.attachments)
-        && s.attachments.length > 0
-      )
-    )
-    // Remove submissions with only deleted files. They are marked with { filename: 'file_removed.pdf' } by SpeedGrader/Canvas
-    // 0 - remove from list, >= 1 - keep in list
-    .filter((s) => s.attachments.reduce((val, next) => next.filename !== "file_removed.pdf" ? val + 1 : val, 0))
+    .filter(_isSubmittedAndHasAttachments)
+    // Remove submissions with only deleted files
+    .filter(_hasRealFilesAsAttachment)
     // Remove submissions witout KTH ID
-    .filter((s) => s.user?.sis_user_id)
+    .filter(_hasSisUserId)
     .map(s => s.user.sis_user_id);
+}
+
+function _isSubmittedAndHasAttachments(s) : boolean {
+  return (
+    s.workflow_state !== "unsubmitted"
+    && Array.isArray(s.attachments)
+    && s.attachments.length > 0
+  );
+}
+
+function _hasRealFilesAsAttachment(s) : boolean {
+  if (!Array.isArray(s.attachments)) {
+    return false;
+  }
+  // Deleted files are marked with { filename: 'file_removed.pdf' } by SpeedGrader/Canvas
+  const nrofActiveFiles = s.attachments.reduce((val, next) => next.filename !== "file_removed.pdf" ? val + 1 : val, 0);
+  return  nrofActiveFiles > 0;
+}
+
+function _hasSisUserId(s) : boolean {
+  return s.user?.sis_user_id ? true : false;
 }
 
 function calcNewSummary({ ...summaryProps }: TErrorSummary, status: string, error: any) : TErrorSummary {


### PR DESCRIPTION
To test this:
1. import exams to a course
2. open SpeedGrader
3. delete an uploaded file using trash can icon
- you will now se the file renamed as "file_removed.pdf"
4. click import more
- you will be prompted with number of available exams to re-import
5.  import, wait and check SpeedGrader

The deleted file "file_removed.pdf" is replaced by the newly imported file.

Tests performed on courseId 32855.