### PR TITLE
Consider only one version per student

### DIFF
--- a/backend/__test__/listAllExams.spec.ts
+++ b/backend/__test__/listAllExams.spec.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "@jest/globals";
-import { _throwIfNotExactlyOneLadokId } from "../src/api/endpointHandlers/listAllExams";
+import {
+  _throwIfNotExactlyOneLadokId,
+  isLastScanned,
+} from "../src/api/endpointHandlers/listAllExams";
 import { EndpointError } from "../src/api/error";
 
 describe("listAllExams", () => {
@@ -39,5 +42,85 @@ describe("listAllExams", () => {
 
       expect(err).toBeUndefined();
     });
+  });
+});
+
+describe("isLastScanned", () => {
+  it("should keep only the 'latest' file for each student", () => {
+    const file1 = {
+      fileId: 1,
+      student: {
+        id: "1",
+      },
+    };
+    const file2 = {
+      fileId: 2,
+      student: {
+        id: "1",
+      },
+    };
+    const file3 = {
+      fileId: 3,
+      student: {
+        id: "2",
+      },
+    };
+    const file4 = {
+      fileId: 4,
+      student: {
+        id: "1",
+      },
+    };
+    const file5 = {
+      fileId: 5,
+      student: {
+        id: "2",
+      },
+    };
+
+    const input = [file1, file2, file3, file4, file5];
+    const output = input.filter(isLastScanned);
+
+    expect(output).toEqual([file4, file5]);
+  });
+
+  it("should keep the file with the highest 'fileId' regardless of order in the array", () => {
+    const file1 = {
+      fileId: 1,
+      student: {
+        id: "1",
+      },
+    };
+    const file2 = {
+      fileId: 2,
+      student: {
+        id: "1",
+      },
+    };
+
+    const input1 = [file1, file2];
+    const output1 = input1.filter(isLastScanned);
+
+    expect(output1).toEqual([file2]);
+
+    const input2 = [file2, file1];
+    const output2 = input2.filter(isLastScanned);
+    expect(output2).toEqual([file2]);
+  });
+
+  it("should not filter out any file with non defined student ID", () => {
+    const file1 = {
+      fileId: 1,
+      student: {},
+    };
+    const file2 = {
+      fileId: 2,
+      student: {},
+    };
+
+    const input = [file1, file2];
+    const output = input.filter(isLastScanned);
+
+    expect(output).toEqual([file1, file2]);
   });
 });

--- a/backend/src/api/endpointHandlers/listAllExams.ts
+++ b/backend/src/api/endpointHandlers/listAllExams.ts
@@ -4,7 +4,6 @@ import * as canvasApi from "../externalApis/canvasApiClient";
 import * as tentaApi from "../externalApis/tentaApiClient";
 import { getEntriesFromQueue } from "../importQueue";
 import { CanvasApiError, EndpointError } from "../error";
-import { totalmem } from "os";
 
 /**
  * Get the "ladokId" that is associated with a given course. It throws in case

--- a/backend/src/api/endpointHandlers/listAllExams.ts
+++ b/backend/src/api/endpointHandlers/listAllExams.ts
@@ -1,7 +1,7 @@
 /** Functions that handle the "import exams" part of the app */
 import log from "skog";
 import * as canvasApi from "../externalApis/canvasApiClient";
-import * as tentaApi from "../externalApis/tentaApiClient";
+import { ScannedExam, examListByLadokId } from "../externalApis/tentaApiClient";
 import { getEntriesFromQueue } from "../importQueue";
 import { CanvasApiError, EndpointError } from "../error";
 
@@ -25,9 +25,25 @@ function throwIfNotExactlyOneLadokId(ladokIds, courseId) {
   }
 }
 
+/**
+ * Returns true if the `current` exam is the "last scanned" one in the array.
+ *
+ * This function is meant to be passed as predicate to "filter" an array of `tentaApi.ScannedExam`
+ */
+export function isLastScanned(
+  current: ScannedExam,
+  index: number,
+  array: ScannedExam[]
+) {
+  const allIds = array.map((exam) => exam.fileId);
+
+  // We are assuming that the "last scanned" will have a "higher" ID
+  return Math.max(...allIds) === current.fileId;
+}
+
 /** Returns a list of scanned exams (i.e. in Windream) given its ladokId */
 async function listScannedExams(courseId, ladokId) {
-  const allScannedExams = await tentaApi.examListByLadokId(ladokId);
+  const allScannedExams = await examListByLadokId(ladokId);
 
   log.info(
     `Obtained exams for course [${courseId}] ladokId [${ladokId}]: ${allScannedExams.length}`

--- a/backend/src/api/error.ts
+++ b/backend/src/api/error.ts
@@ -317,7 +317,7 @@ function errorHandler(err, req, res, next) {
   });
 }
 
-function tentaApiGenericErrorHandler(err) {
+function tentaApiGenericErrorHandler(err): never {
   Error.captureStackTrace(err, tentaApiGenericErrorHandler);
   const error = new TentaApiError({
     err, // Pass the original error

--- a/backend/src/api/externalApis/tentaApiClient.ts
+++ b/backend/src/api/externalApis/tentaApiClient.ts
@@ -5,7 +5,7 @@ import { Readable } from "stream";
 import { tentaApiGenericErrorHandler } from "../error";
 
 /** An exam that exists in "Tenta API" */
-interface ScannedExam {
+export interface ScannedExam {
   /** Unique ID for the exam */
   fileId: number;
 

--- a/backend/src/api/externalApis/tentaApiClient.ts
+++ b/backend/src/api/externalApis/tentaApiClient.ts
@@ -4,6 +4,24 @@ import { Readable } from "stream";
 
 import { tentaApiGenericErrorHandler } from "../error";
 
+/** An exam that exists in "Tenta API" */
+interface ScannedExam {
+  /** Unique ID for the exam */
+  fileId: number;
+
+  /** Student data */
+  student: {
+    /** Student KTH ID */
+    id?: string;
+
+    /** Student first name */
+    firstName?: string;
+
+    /** Student last name */
+    lastName?: string;
+  };
+}
+
 const client = got.extend({
   prefixUrl: process.env.TENTA_API_URL,
   headers: {
@@ -17,10 +35,10 @@ async function getVersion() {
   return body;
 }
 
-async function examListByLadokId(ladokId) {
+async function examListByLadokId(ladokId): Promise<ScannedExam[]> {
   log.debug(`Getting exams for Ladok ID ${ladokId}`);
 
-  const { body } = (await client("windream/search/documents/false", {
+  const { body } = await client<any>("windream/search/documents/false", {
     method: "POST",
     json: {
       searchIndiceses: [
@@ -35,14 +53,14 @@ async function examListByLadokId(ladokId) {
       useDatesInSearch: false,
     },
     responseType: "json",
-  }).catch(tentaApiGenericErrorHandler)) as any;
+  }).catch(tentaApiGenericErrorHandler);
 
   if (!body.documentSearchResults) {
     log.debug(`No exams found with the "new format" e_ladokid=${ladokId}`);
     return [];
   }
 
-  const list = [];
+  const list: ScannedExam[] = [];
 
   for (const result of body.documentSearchResults) {
     // Helper function to get the value of the attribute called "index"


### PR DESCRIPTION
This PR implements a function that ensures that, if a student has more than one exam scanned, it adds only the latest scanned one to the import queue.

Additionally this PR:

- Runs prettier in some files (sorry, I have "run on save" activated)
- Adds some tests to the function explained above.