### PR TITLE
Feature upload all available files

### DIFF
--- a/backend/__test__/importQueue.spec.ts
+++ b/backend/__test__/importQueue.spec.ts
@@ -51,6 +51,7 @@ describe("Import queue", () => {
   it("should add one entry to queue", async () => {
     const entry = {
       fileId: stringToInt("file1"),
+      fileCreateDate: "2022-01-01T00:01:01",
       courseId: "mainTestCourse",
       userKthId: "u23z456",
     };
@@ -64,6 +65,7 @@ describe("Import queue", () => {
   it("should add one entry to queue with numeric fileId", async () => {
     const entry = {
       fileId: 1234,
+      fileCreateDate: "2022-01-01T00:01:01",
       courseId: "mainTestCourse",
       userKthId: "u23z456",
     };
@@ -77,11 +79,13 @@ describe("Import queue", () => {
   it("should not add entry with same fileId twice", async () => {
     const entry1 = {
       fileId: stringToInt("twice1"),
+      fileCreateDate: "2022-01-01T00:01:01",
       courseId: "mainTestCourse",
       userKthId: "u23z456",
     };
     const entry2 = {
       fileId: stringToInt("twice1"),
+      fileCreateDate: "2022-01-01T00:01:01",
       courseId: "mainTestCourse",
       userKthId: "u23z456",
     };
@@ -101,6 +105,7 @@ describe("Import queue", () => {
   it("should list only entries with correct courseId", async () => {
     const entry1 = {
       fileId: stringToInt("filter1"),
+      fileCreateDate: "2022-01-01T00:01:01",
       courseId: "mainTestCourse",
       userKthId: "u23z456",
     };
@@ -108,6 +113,7 @@ describe("Import queue", () => {
 
     const entry2 = {
       fileId: stringToInt("filter2"),
+      fileCreateDate: "2022-01-01T00:01:01",
       courseId: "mainTestCourse",
       userKthId: "u23z456",
     };
@@ -115,6 +121,7 @@ describe("Import queue", () => {
 
     const entry = {
       fileId: stringToInt("filter3"),
+      fileCreateDate: "2022-01-01T00:01:01",
       courseId: "listTest123",
       userKthId: "u23z456",
     };
@@ -134,6 +141,7 @@ describe("Import queue", () => {
   it("should allow updating status of entry in queue to 'pending'", async () => {
     const entry = {
       fileId: stringToInt("pendingFile1"),
+      fileCreateDate: "2022-01-01T00:01:01",
       courseId: "mainTestCourse",
       userKthId: "u233z456",
     };
@@ -153,6 +161,7 @@ describe("Import queue", () => {
   it("should allow updating status of entry in queue to 'imported'", async () => {
     const entry = {
       fileId: stringToInt("importedFile1"),
+      fileCreateDate: "2022-01-01T00:01:01",
       courseId: "mainTestCourse",
       userKthId: "u133z456",
     };
@@ -171,6 +180,7 @@ describe("Import queue", () => {
   it("should allow updating status of entry in queue to 'error' w/o details", async () => {
     const entry = {
       fileId: stringToInt("errorFile1"),
+      fileCreateDate: "2022-01-01T00:01:01",
       courseId: "mainTestCourse",
       userKthId: "u333z456",
     };
@@ -190,6 +200,7 @@ describe("Import queue", () => {
   it("should allow updating status of entry in queue to 'error' with details", async () => {
     const entry = {
       fileId: stringToInt("errorFile2"),
+      fileCreateDate: "2022-01-01T00:01:01",
       courseId: "mainTestCourse",
       userKthId: "u3433z456",
     };
@@ -212,6 +223,7 @@ describe("Import queue", () => {
   it("should provide status summary of queue ('working')", async () => {
     const entry = {
       fileId: stringToInt("errorFile2"),
+      fileCreateDate: "2022-01-01T00:01:01",
       courseId: "mainTestCourse",
       userKthId: "u3433z456",
       status: "pending",
@@ -229,6 +241,7 @@ describe("Import queue", () => {
     let statusSummary;
     const entry = {
       fileId: stringToInt("statusFile1"),
+      fileCreateDate: "2022-01-01T00:01:01",
       courseId: "statusTestCourse",
       userKthId: "u3433z456",
     };
@@ -264,6 +277,7 @@ describe("Get first element from queue", () => {
   it("should return null if there is no `pending` element", async () => {
     const entry1 = {
       fileId: stringToInt("statusFile1"),
+      fileCreateDate: "2022-01-01T00:01:01",
       courseId: "statusTestCourse",
       userKthId: "u3433z456",
       status: "success",
@@ -277,6 +291,7 @@ describe("Get first element from queue", () => {
   it("should return the first element if something is enqueued", async () => {
     const entry1 = {
       fileId: stringToInt("statusFile1"),
+      fileCreateDate: "2022-01-01T00:01:01",
       courseId: "statusTestCourse",
       userKthId: "u3433z456",
       status: "pending",
@@ -292,6 +307,7 @@ describe("Get first element from queue", () => {
   it("should return the first `pending` element", async () => {
     const entry1 = {
       fileId: stringToInt("statusFile1"),
+      fileCreateDate: "2022-01-01T00:01:01",
       courseId: "statusTestCourse",
       userKthId: "u3433z456",
       status: "pending",
@@ -299,6 +315,7 @@ describe("Get first element from queue", () => {
 
     const entry2 = {
       fileId: stringToInt("statusFile2"),
+      fileCreateDate: "2022-01-01T00:01:01",
       courseId: "statusTestCourse",
       userKthId: "u3433z456",
       status: "pending",
@@ -327,6 +344,7 @@ describe("Resetting a queue", () => {
       await addEntryToQueue(
         new QueueEntry({
           fileId: i,
+          fileCreateDate: "2022-01-01T00:01:01",
           courseId,
           student: undefined,
           status: i < 8 ? "imported" : "error",

--- a/backend/src/api/assignmentLock.ts
+++ b/backend/src/api/assignmentLock.ts
@@ -42,10 +42,13 @@ export function propertiesToCreateLockedAssignment(examDate) {
 }
 
 function _generateTimeWithOffset(offset: number) {
-  const secs = offset % 60;
-  const mins = Math.floor(offset / 60) % 60;
-  const hours = Math.floor(offset / (60 * 60)) % 24;
-  return `${hours > 9 ? hours : '0' + hours}:${mins > 9 ? mins : '0' + mins}:${secs > 9 ? secs : '0' + secs}`;
+  const secs = (offset % 60)
+    .toString().padStart(2, '0');
+  const mins = (Math.floor(offset / 60) % 60)
+    .toString().padStart(2, '0');
+  const hours = (Math.floor(offset / (60 * 60)) % 24)
+    .toString().padStart(2, '0');
+  return `${hours}:${mins}:${secs}`;
 }
 
 export function propertiesToCreateSubmission(examDate, nrofSubmissions) {

--- a/backend/src/api/assignmentLock.ts
+++ b/backend/src/api/assignmentLock.ts
@@ -41,10 +41,18 @@ export function propertiesToCreateLockedAssignment(examDate) {
   };
 }
 
-export function propertiesToCreateSubmission(examDate) {
+function _generateTimeWithOffset(offset: number) {
+  const secs = offset % 60;
+  const mins = Math.floor(offset / 60) % 60;
+  const hours = Math.floor(offset / (60 * 60)) % 24;
+  return `${hours > 9 ? hours : '0' + hours}:${mins > 9 ? mins : '0' + mins}:${secs > 9 ? secs : '0' + secs}`;
+}
+
+export function propertiesToCreateSubmission(examDate, nrofSubmissions) {
+  // TODO: If we submit on the same timestamp, the old submission gets overwritten
   return {
     // This ensures us that the things we upload are not considered "LATE"
-    submitted_at: `${examDate}T00:00:00`,
+    submitted_at: `${examDate}T${_generateTimeWithOffset(nrofSubmissions)}`,
   };
 }
 

--- a/backend/src/api/endpointHandlers/listAllExams.ts
+++ b/backend/src/api/endpointHandlers/listAllExams.ts
@@ -169,6 +169,16 @@ async function listAllExams(req, res, next) {
       errorsByType: {},
     };
 
+    // Sort exams on createDate in ascending order
+    allScannedExams.sort((a, b) => {
+      if (a.createDate < b.createDate) {
+        return -1;
+      } else if (a.createDate > b.createDate) {
+        return 1;
+      } else {
+        return 0;
+      }
+    })
     const listOfExamsToHandle = allScannedExams.map((exam) => {
       const foundInCanvas = studentsWithExamsInCanvas.find(
         (s) => s === exam.student?.id
@@ -206,6 +216,7 @@ async function listAllExams(req, res, next) {
 
       return {
         id: exam.fileId,
+        createDate: exam.createDate,
         student: exam.student,
         status,
         error: errorDetails,

--- a/backend/src/api/endpointHandlers/listAllExams.ts
+++ b/backend/src/api/endpointHandlers/listAllExams.ts
@@ -42,7 +42,13 @@ async function listScannedExams(courseId, ladokId) {
 async function listStudentSubmissionsInCanvas(
   courseId,
   ladokId
-): Promise<{submission_history}[]> {
+): Promise<{
+    submission_history: {
+      attachments: {
+        filename: string
+      }[]
+    }[]
+  }[]> {
   const assignment = await canvasApi
     .getValidAssignment(courseId, ladokId)
     .then((result) => {

--- a/backend/src/api/endpointHandlers/listAllExams.ts
+++ b/backend/src/api/endpointHandlers/listAllExams.ts
@@ -47,7 +47,10 @@ async function listStudentSubmissionsInCanvas(
       attachments: {
         filename: string
       }[]
-    }[]
+    }[],
+    user: {
+      sis_user_id: string
+    }
   }[]> {
   const assignment = await canvasApi
     .getValidAssignment(courseId, ladokId)
@@ -156,17 +159,17 @@ async function listAllExams(req, res, next) {
     // The key is a string and the object contains at least a filename.
     const attachmentsInCanvas: { [key: string]: { filename: string }} = {};
     studentsWithSubmissionsInCanvas.forEach(
-      (s) => s.submission_history?.forEach((submission) => {
-        submission.attachments?.forEach((attachment) => {
+      (submission) => submission.submission_history?.forEach((prevSubmission) => {
+        prevSubmission.attachments?.forEach((attachment) => {
           // QUESTION: Should we warn if we have a duplicate upload?
           // NOTE: file_removed.pdf has the same name everywhere
-          attachmentsInCanvas[attachment.filename] = attachment;
+          attachmentsInCanvas[`${submission.user?.sis_user_id}-${attachment.filename}`] = attachment;
         })
       })
     );
 
     const listOfExamsToHandle = allScannedExams.map((exam) => {
-      const foundInCanvas = attachmentsInCanvas[`${exam.fileId}.pdf`];
+      const foundInCanvas = attachmentsInCanvas[`${exam.student?.id}-${exam.fileId}.pdf`];
 
       const foundInQueue = examsInImportQueue.find(
         (examInQueue) => examInQueue.fileId === exam.fileId

--- a/backend/src/api/error.ts
+++ b/backend/src/api/error.ts
@@ -189,6 +189,28 @@ class ImportError extends OperationalError {
   }
 }
 
+class FileUploadError extends OperationalError {
+  /**
+   * FileUploadError – all errors that can occur when trying to upload files to storage.
+   * This should be thrown at the integration layer.
+   * @param {object} param0 Error params
+   * @param {String} param0.type Subtype of error
+   * @param {Number=} param0.statusCode HTTP status code of response
+   * @param {String} param0.message Error message for programmer
+   * @param {object=} param0.details Additional error details for used by programmer
+   * @param {Error=} param0.err The original error that caused this error
+   */
+  constructor({
+    type,
+    statusCode = 503,
+    message,
+    details = undefined,
+    err = undefined,
+  }) {
+    super("FileUploadError", statusCode, type, message, details, err);
+  }
+}
+
 /**
  * Helper method for catch block
  * @param {object} err Error object passed to catch block
@@ -336,6 +358,7 @@ export {
   AuthError,
   EndpointError,
   ImportError,
+  FileUploadError,
   CanvasApiError,
   LadokApiError,
   TentaApiError,

--- a/backend/src/api/externalApis/canvasApiClient.ts
+++ b/backend/src/api/externalApis/canvasApiClient.ts
@@ -267,7 +267,7 @@ async function uploadExam(
         `courses/${courseId}/assignments/${assignment.id}/submissions/${user.id}/files`,
         "POST",
         {
-          name: `${studentKthId}.pdf`,
+          name: `${fileId}.pdf`,
         }
       )
       .catch((err) => {

--- a/backend/src/api/externalApis/canvasApiClient.ts
+++ b/backend/src/api/externalApis/canvasApiClient.ts
@@ -132,7 +132,13 @@ async function getAssignmentSubmissions(courseId, assignmentId) {
       `courses/${courseId}/assignments/${assignmentId}/submissions`,
       { include: ["user", "submission_history"] } // include user obj with kth id
     )
-    .toArray() as any;
+    .toArray() as Promise<{
+      submission_history: {
+        attachments: {
+          filename: string
+        }[]
+      }[]
+    }[]>;
 }
 
 async function createAssignment(courseId, ladokId, language = "en") {

--- a/backend/src/api/externalApis/canvasApiClient.ts
+++ b/backend/src/api/externalApis/canvasApiClient.ts
@@ -137,7 +137,10 @@ async function getAssignmentSubmissions(courseId, assignmentId) {
         attachments: {
           filename: string
         }[]
-      }[]
+      }[],
+      user: {
+        sis_user_id: string
+      }
     }[]>;
 }
 

--- a/backend/src/api/externalApis/canvasApiClient.ts
+++ b/backend/src/api/externalApis/canvasApiClient.ts
@@ -83,7 +83,7 @@ async function getAktivitetstillfalleUIDs(courseId) {
   // the same Ladok ID)
   const uniqueIds = Array.from(new Set(sisIds));
 
-  return uniqueIds as String[];
+  return uniqueIds as string[];
 }
 
 // TODO: this function is kept only for backwards-compatibility reasons
@@ -108,7 +108,7 @@ async function getExaminationLadokId(courseId) {
       `Course ${courseId} not supported: it is connected to ${uniqueIds.length} different Ladok Ids`
     );
   } else {
-    return uniqueIds[0] as String;
+    return uniqueIds[0] as string;
   }
 }
 
@@ -385,7 +385,7 @@ async function getAssignmentSubmissionForStudent({
   assignmentId,
   userId,
 }) {
-  return canvas.get<{ submission_history: { workflow_state: String }[] }>(
+  return canvas.get<{ submission_history: { workflow_state: string }[] }>(
     `courses/${courseId}/assignments/${assignmentId}/submissions/${userId}`,
     { include: ["submission_history"] }
   );

--- a/backend/src/api/externalApis/canvasApiClient.ts
+++ b/backend/src/api/externalApis/canvasApiClient.ts
@@ -130,7 +130,7 @@ async function getAssignmentSubmissions(courseId, assignmentId) {
   return canvas
     .listItems(
       `courses/${courseId}/assignments/${assignmentId}/submissions`,
-      { include: "user" } // include user obj with kth id
+      { include: ["user", "submission_history"] } // include user obj with kth id
     )
     .toArray() as any;
 }
@@ -305,18 +305,36 @@ async function uploadExam(
     // TODO: move the following statement outside of this function
     // Reason: this module (canvasApiClient) should not contain "business rules"
     await unlockAssignment(courseId, assignment.id);
+
+    // Get existing submission history for this student and assignment to figure out
+    // timestamp offset. If we submit on the same timestamp (submitted_at), the old
+    // submission gets overwritten.
+    const { body: submission } = await getAssignmentSubmissionForStudent({
+      courseId,
+      assignmentId: assignment.id,
+      userId: user.id,
+    });
+
+    // There is always a submission to start with in the history with status "unsubmitted"
+    // so we need to filter that out when getting nrof actual submissions
+    const nrofSubmissions = submission.submission_history?.filter(s => s.workflow_state !== "unsubmitted").length ?? 0;
+    const submissionProps = propertiesToCreateSubmission(examDate, nrofSubmissions);
+    const { submitted_at } = submissionProps;
+
     await canvas.request(
       `courses/${courseId}/assignments/${assignment.id}/submissions/`,
       "POST",
       {
         submission: {
-          ...propertiesToCreateSubmission(examDate),
+          ...submissionProps,
           submission_type: "online_upload",
           user_id: user.id,
           file_ids: [uploadedFile.id],
         },
       }
     );
+
+    return submitted_at;
   } catch (err) {
     if (err.type === "missing_student") {
       log.warn(`User ${studentKthId} is missing in Canvas course ${courseId}`);
@@ -360,6 +378,17 @@ async function getRoles(courseId, userId) {
   return enrollments
     .filter((enr) => enr.user_id === userId)
     .map((enr) => enr.role_id);
+}
+
+async function getAssignmentSubmissionForStudent({
+  courseId,
+  assignmentId,
+  userId,
+}) {
+  return canvas.get<{ submission_history: { workflow_state: String }[] }>(
+    `courses/${courseId}/assignments/${assignmentId}/submissions/${userId}`,
+    { include: ["submission_history"] }
+  );
 }
 
 async function enrollStudent(courseId, userId) {

--- a/backend/src/api/externalApis/tentaApiClient.ts
+++ b/backend/src/api/externalApis/tentaApiClient.ts
@@ -17,7 +17,17 @@ async function getVersion() {
   return body;
 }
 
-async function examListByLadokId(ladokId) {
+interface WindreamsScannedExam {
+  createDate: String;
+  fileId: Number;
+  student: {
+    id: String;
+    firstName: String;
+    lastName: String;
+  }
+}
+
+async function examListByLadokId(ladokId): Promise<WindreamsScannedExam[]> {
   log.debug(`Getting exams for Ladok ID ${ladokId}`);
 
   const { body } = (await client("windream/search/documents/false", {
@@ -51,6 +61,7 @@ async function examListByLadokId(ladokId) {
       result.documentIndiceses.find((di) => di.index === index)?.value;
 
     list.push({
+      createDate: result.createDate,
       fileId: result.fileId,
       student: {
         id: getValue("s_uid"),

--- a/backend/src/api/externalApis/tentaApiClient.ts
+++ b/backend/src/api/externalApis/tentaApiClient.ts
@@ -18,12 +18,12 @@ async function getVersion() {
 }
 
 interface WindreamsScannedExam {
-  createDate: String;
-  fileId: Number;
+  createDate: string;
+  fileId: number;
   student: {
-    id: String;
-    firstName: String;
-    lastName: String;
+    id: string;
+    firstName: string;
+    lastName: string;
   }
 }
 

--- a/backend/src/api/externalApis/tentaApiClient.ts
+++ b/backend/src/api/externalApis/tentaApiClient.ts
@@ -28,6 +28,8 @@ interface WindreamsScannedExam {
 }
 
 async function examListByLadokId(ladokId): Promise<WindreamsScannedExam[]> {
+  const outp = <WindreamsScannedExam[]>[];
+
   log.debug(`Getting exams for Ladok ID ${ladokId}`);
 
   const { body } = (await client("windream/search/documents/false", {
@@ -52,15 +54,13 @@ async function examListByLadokId(ladokId): Promise<WindreamsScannedExam[]> {
     return [];
   }
 
-  const list = [];
-
   for (const result of body.documentSearchResults) {
     // Helper function to get the value of the attribute called "index"
     // we have written it because they are in an array instead of an object
     const getValue = (index) =>
       result.documentIndiceses.find((di) => di.index === index)?.value;
 
-    list.push({
+    outp.push({
       createDate: result.createDate,
       fileId: result.fileId,
       student: {
@@ -76,7 +76,7 @@ async function examListByLadokId(ladokId): Promise<WindreamsScannedExam[]> {
     return [];
   }
 
-  return list;
+  return outp;
 }
 
 /** Download the exam with ID "fileId". Returns its content as a ReadableStream */

--- a/backend/src/api/importQueue/index.ts
+++ b/backend/src/api/importQueue/index.ts
@@ -248,7 +248,10 @@ async function resetQueueForImport(courseId) {
 
 async function addEntryToQueue(entry) {
   assert(entry.fileId !== undefined, "Param entry is missing fileId");
-  assert(entry.fileCreateDate !== undefined, "Param entry is missing fileCreateDate");
+  assert(
+    entry.fileCreateDate !== undefined,
+    "Param entry is missing fileCreateDate"
+  );
   assert(entry.courseId !== undefined, "Param entry is missing courseId");
 
   // Type object to get defaults
@@ -458,7 +461,10 @@ async function updateStatusOfEntryInQueue(
 async function getFirstPendingFromQueue() {
   try {
     const collImportQueue = await getImportQueueCollection();
-    const doc = await collImportQueue.findOne({ status: "pending" }, { sort: { "fileCreateDate": 1 }, },);
+    const doc = await collImportQueue.findOne(
+      { status: "pending" },
+      { sort: { fileCreateDate: 1 } }
+    );
 
     if (!doc) {
       return null;

--- a/backend/src/api/importQueue/index.ts
+++ b/backend/src/api/importQueue/index.ts
@@ -56,6 +56,7 @@ export type TQueueEntryError = {
 
 class QueueEntry {
   fileId: number;
+  fileCreateDate: string;
   courseId: number;
   student: TStudent;
   status: string;
@@ -67,6 +68,7 @@ class QueueEntry {
 
   constructor({
     fileId,
+    fileCreateDate,
     courseId,
     student,
     status = "new",
@@ -77,6 +79,7 @@ class QueueEntry {
     error,
   }) {
     this.fileId = fileId;
+    this.fileCreateDate = fileCreateDate;
     this.courseId = courseId;
     this.student = {
       kthId: student?.kthId,
@@ -94,6 +97,7 @@ class QueueEntry {
   toJSON() {
     return {
       fileId: this.fileId,
+      fileCreateDate: this.fileCreateDate,
       courseId: this.courseId,
       student: {
         kthId: this.student?.kthId,
@@ -244,6 +248,7 @@ async function resetQueueForImport(courseId) {
 
 async function addEntryToQueue(entry) {
   assert(entry.fileId !== undefined, "Param entry is missing fileId");
+  assert(entry.fileCreateDate !== undefined, "Param entry is missing fileCreateDate");
   assert(entry.courseId !== undefined, "Param entry is missing courseId");
 
   // Type object to get defaults
@@ -453,7 +458,7 @@ async function updateStatusOfEntryInQueue(
 async function getFirstPendingFromQueue() {
   try {
     const collImportQueue = await getImportQueueCollection();
-    const doc = await collImportQueue.findOne({ status: "pending" });
+    const doc = await collImportQueue.findOne({ status: "pending" }, { sort: { "fileCreateDate": 1 }, },);
 
     if (!doc) {
       return null;

--- a/backend/src/api/importQueue/processQueueEntry.ts
+++ b/backend/src/api/importQueue/processQueueEntry.ts
@@ -58,7 +58,7 @@ async function uploadOneExam({ fileId, courseId }) {
     `Course ${courseId} / File ${fileId}, ${fileName} / User ${student.kthId}. Uploading`
   );
   const uploadExamStart = Date.now();
-  await canvasApi.uploadExam(content, {
+  const submissionTimestamp = await canvasApi.uploadExam(content, {
     courseId,
     studentKthId: student.kthId,
     examDate,
@@ -67,7 +67,7 @@ async function uploadOneExam({ fileId, courseId }) {
   log.debug("Time to upload exam: " + (Date.now() - uploadExamStart) + "ms");
 
   log.info(
-    `Course ${courseId} / File ${fileId}, ${fileName} / User ${student.kthId}. Uploaded!`
+    `Course ${courseId} / File ${fileId}, ${fileName} / User ${student.kthId}. Uploaded! Timestamp @ ${submissionTimestamp}`
   );
 }
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -75,7 +75,7 @@ server.use(cookieParser());
 //               like CSS files)
 // - /auth       routes for the authorization process
 // - /_monitor   just the monitor page
-function _showOnlyHostname(inp: String): String {
+function _showOnlyHostname(inp: string): string {
   const tmpIn = inp.startsWith("http") ? inp : `https://${inp}`;
   const tmpOut = tmpIn.match(/https?:\/\/[^\/]*/m);
   if (tmpOut != null) {

--- a/frontend/src/common/api.js
+++ b/frontend/src/common/api.js
@@ -171,7 +171,12 @@ export function useMutateImportStart(courseId, examsToImport, options = {}) {
     () =>
       apiClient(`courses/${courseId}/import-queue`, {
         method: "POST",
-        body: examsToImport.map((exam) => exam.id),
+        body: examsToImport.map((exam) => {
+          return {
+            id: exam.id,
+            createDate: exam.createDate,
+          };
+        }),
       }),
     {
       ...options,


### PR DESCRIPTION
Notes:
- I have annotated the commits to give a clearer idea of what they do, but they should be tested as a complete set of changes
- Mongodb has been inconsistent in fetch order, but this is sorted by storing createDate from Windreams
- To provide multiple submissions each must have a unique `submit_at` value otherwise the previous is overwritten
- Windreams appear to return documents in order, but I am not assuming this

IMPORTANT: If an import of a file fails (which can happen if the Canvas API acts up) this file could be imported after a file that is scanned later. When the file is eventually imported to Canvas it will appear to have been submitted later. This is an edge case and requires the a failed import combined with multiple files in Windreams.
- Fixing this adds a lot of complexity
- The work around is to delete the file that should be the last submission and re-import