### PR TITLE
Endpoint errors without .err property set shouldn't be logged as errors

### DIFF
--- a/backend/src/api/error.ts
+++ b/backend/src/api/error.ts
@@ -297,8 +297,9 @@ function errorHandler(err, req, res, next) {
     const logErr = getMostSignificantError(err);
     const progErr = getOrigProgrammerError(err);
 
-    if (progErr === undefined) {
-      // If the EndpointError wasn't caused by a programmer error we only need to inform about it.
+    if (err.err === undefined) {
+      // Endpoint errors without .err property set wasn't triggered by a programmer error
+      // and shouldn't be logged as errors
       log.info(logErr);
     } else {
       // If it was a programmer error it needs to be logged and fixed.

--- a/backend/src/api/error.ts
+++ b/backend/src/api/error.ts
@@ -295,14 +295,14 @@ function errorHandler(err, req, res, next) {
     // Since EndpointErrors can wrap other errors we want to make sure we log the most significant error
     // and the underlying programmer error if one exists
     const logErr = getMostSignificantError(err);
-    const progErr = getOrigProgrammerError(err);
-
+    
     if (err.err === undefined) {
       // Endpoint errors without .err property set wasn't triggered by a programmer error
       // and shouldn't be logged as errors
       log.info(logErr);
     } else {
       // If it was a programmer error it needs to be logged and fixed.
+      const progErr = getOrigProgrammerError(err);
       log.error(
         progErr, // this provides a stack trace for the original error that needs to be fixed
         _formatErrorMsg(logErr.name, logErr.type, logErr.message)


### PR DESCRIPTION
This solves alerts spamming and was due to a bug in the error handler that caused all EndpointError type errors to be logged with log.error.