### PR TITLE
One collection per canvas room

### DIFF
--- a/backend/src/api/endpointHandlers/importQueueHandlers.ts
+++ b/backend/src/api/endpointHandlers/importQueueHandlers.ts
@@ -59,6 +59,7 @@ async function addEntriesToQueue(req, res, next) {
             {
               id,
             },
+            courseId,
             "pending"
           );
         }
@@ -116,7 +117,7 @@ async function fixErrorsInQueue(req, res, next) {
 
     for (const fileId of fileIds) {
       // eslint-disable-next-line no-await-in-loop
-      const entry = await getEntryFromQueue(fileId);
+      const entry = await getEntryFromQueue(fileId, courseId);
 
       if (entry.error?.type === "missing_student") {
         // Add student to Canvas
@@ -131,7 +132,7 @@ async function fixErrorsInQueue(req, res, next) {
       }
 
       // eslint-disable-next-line no-await-in-loop
-      await updateStatusOfEntryInQueue(entry, "pending");
+      await updateStatusOfEntryInQueue(entry, courseId, "pending");
     }
 
     res.send({
@@ -167,7 +168,7 @@ async function ignoreErrorsInQueue(req, res, next) {
 
     for (const fileId of fileIds) {
       // eslint-disable-next-line no-await-in-loop
-      await updateStatusOfEntryInQueue({ fileId }, "ignored");
+      await updateStatusOfEntryInQueue({ fileId }, courseId, "ignored");
     }
 
     res.send({

--- a/backend/src/api/externalApis/tentaApiClient.ts
+++ b/backend/src/api/externalApis/tentaApiClient.ts
@@ -30,7 +30,7 @@ interface WindreamsScannedExam {
 async function examListByLadokId(ladokId): Promise<WindreamsScannedExam[]> {
   const outp = <WindreamsScannedExam[]>[];
 
-  log.debug(`Getting exams for Ladok ID ${ladokId}`);
+  log.info(`Getting exams for Ladok ID ${ladokId}`);
 
   const { body } = (await client("windream/search/documents/false", {
     method: "POST",

--- a/backend/src/api/importQueue/index.ts
+++ b/backend/src/api/importQueue/index.ts
@@ -23,6 +23,8 @@ export async function listAllQueues() {
     .db(DB_NAME)
     .listCollections()
     .toArray();
+
+  return collections.filter((c) => c.name.startsWith(DB_QUEUE_NAME));
 }
 
 /**

--- a/backend/src/api/importQueue/index.ts
+++ b/backend/src/api/importQueue/index.ts
@@ -16,7 +16,7 @@ function connectToDatabase() {
   return databaseConnection;
 }
 
-export async function listAllCollections() {
+export async function listAllQueues() {
   await connectToDatabase();
   const collections = await databaseClient.db().listCollections().toArray();
   return collections.filter((c) => c.name.startsWith(DB_QUEUE_NAME));
@@ -32,8 +32,8 @@ async function getImportQueueCollection(courseId: number) {
   // Instansiate once, but not before it is used the first time
   await connectToDatabase();
 
-  const collectionName = `${DB_QUEUE_NAME}_${courseId}`;
-  return databaseClient.db().collection(DB_QUEUE_NAME);
+  const collectionName = `${DB_QUEUE_NAME}:${courseId}`;
+  return databaseClient.db().collection(collectionName);
 }
 
 /**

--- a/backend/src/api/importQueue/index.ts
+++ b/backend/src/api/importQueue/index.ts
@@ -33,7 +33,13 @@ async function getImportQueueCollection(courseId: number) {
   await connectToDatabase();
 
   const collectionName = `${DB_QUEUE_NAME}:${courseId}`;
-  return databaseClient.db().collection(collectionName);
+  const collection = databaseClient.db().collection(collectionName);
+  const oneMonth = 60 * 60 * 24 * 30;
+  collection.createIndex(
+    { createdAt: 1 },
+    { expireAfterSeconds: oneMonth, background: true }
+  );
+  return collection;
 }
 
 /**

--- a/backend/src/api/importQueue/index.ts
+++ b/backend/src/api/importQueue/index.ts
@@ -4,6 +4,7 @@ import { ImportError } from "../error";
 
 const { MONGODB_CONNECTION_STRING } = process.env;
 const DB_QUEUE_NAME = "import_queue";
+const DB_NAME = "import-exams";
 
 const databaseClient = new MongoClient(MONGODB_CONNECTION_STRING, {
   maxPoolSize: 5,
@@ -18,8 +19,10 @@ function connectToDatabase() {
 
 export async function listAllQueues() {
   await connectToDatabase();
-  const collections = await databaseClient.db().listCollections().toArray();
-  return collections.filter((c) => c.name.startsWith(DB_QUEUE_NAME));
+  const collections = await databaseClient
+    .db(DB_NAME)
+    .listCollections()
+    .toArray();
 }
 
 /**
@@ -33,7 +36,7 @@ async function getImportQueueCollection(courseId: number) {
   await connectToDatabase();
 
   const collectionName = `${DB_QUEUE_NAME}:${courseId}`;
-  const collection = databaseClient.db().collection(collectionName);
+  const collection = databaseClient.db(DB_NAME).collection(collectionName);
   const oneMonth = 60 * 60 * 24 * 30;
   collection.createIndex(
     { createdAt: 1 },

--- a/backend/src/api/importQueue/processQueueEntry.ts
+++ b/backend/src/api/importQueue/processQueueEntry.ts
@@ -52,7 +52,7 @@ async function uploadOneExam({ fileId, courseId }) {
     studentPersNr: student.personNumber,
   });
 
-  await updateStudentOfEntryInQueue({ fileId }, student);
+  await updateStudentOfEntryInQueue({ fileId }, courseId, student);
 
   log.debug(
     `Course ${courseId} / File ${fileId}, ${fileName} / User ${student.kthId}. Uploading`
@@ -111,8 +111,8 @@ function handleUploadErrors(err, exam) {
  * Find and process an entry from the global import queue and exit
  * @returns {bool} return true is entry was processed and false if queue was empty
  */
-export async function processQueueEntry() {
-  const examToBeImported = await getFirstPendingFromQueue();
+export async function processQueueEntry(courseId: number) {
+  const examToBeImported = await getFirstPendingFromQueue(courseId);
 
   if (examToBeImported) {
     // Log the courseId for this operation
@@ -136,13 +136,13 @@ export async function processQueueEntry() {
         });
 
       // Update status in import queue
-      await updateStatusOfEntryInQueue(examToBeImported, "imported");
+      await updateStatusOfEntryInQueue(examToBeImported, courseId, "imported");
 
       if (IS_DEV) log.debug("Imported file " + examToBeImported.fileId);
     } catch (err) {
       // TODO: Improve handling of errors, at least adding a more user
       // friendly message
-      await updateStatusOfEntryInQueue(examToBeImported, "error", {
+      await updateStatusOfEntryInQueue(examToBeImported, courseId, "error", {
         type: err.type || err.name,
         message: err.message,
         details: err.details || {},

--- a/backend/src/importWorker.ts
+++ b/backend/src/importWorker.ts
@@ -11,6 +11,7 @@ export async function startBackgroundImport() {
     try {
       // TODO: how should this be handled? This should handle all courses in parallell...
       // one way would be to list all collections with a name standand, and process them all in parallell. But this would grow each time the app is used, and the collections are not removed. Can they be removed without input to the user is lost?
+      // I could perhaps just use ttl on the documents, to a month?
      const collections = await listAllCollections();
      Promise.all(collections.map((c)=> processQueueEntry(c.name)));
 

--- a/backend/src/importWorker.ts
+++ b/backend/src/importWorker.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-await-in-loop */
 import log from "skog";
 import { processQueueEntry } from "./api/importQueue/processQueueEntry";
-import { listAllCollections } from "./api/importQueue/
+import { listAllQueues } from "./api/importQueue/";
 export async function startBackgroundImport() {
   log.info("Start background import");
   // eslint-disable-next-line no-constant-condition
@@ -12,9 +12,14 @@ export async function startBackgroundImport() {
       // TODO: how should this be handled? This should handle all courses in parallell...
       // one way would be to list all collections with a name standand, and process them all in parallell. But this would grow each time the app is used, and the collections are not removed. Can they be removed without input to the user is lost?
       // I could perhaps just use ttl on the documents, to a month?
-     const collections = await listAllCollections();
-     Promise.all(collections.map((c)=> processQueueEntry(c.name)));
+      const collections = await listAllQueues();
 
+      await Promise.all(
+        collections.map((c) => {
+          const courseNumber = parseInt(c.name.split(":")[1]);
+          processQueueEntry(courseNumber);
+        })
+      );
     } catch (err) {
       log.error({ err }, "Unexpected error when processing a Queue Entry");
     }

--- a/backend/src/importWorker.ts
+++ b/backend/src/importWorker.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-await-in-loop */
 import log from "skog";
 import { processQueueEntry } from "./api/importQueue/processQueueEntry";
-
+import { listAllCollections } from "./api/importQueue/
 export async function startBackgroundImport() {
   log.info("Start background import");
   // eslint-disable-next-line no-constant-condition
@@ -9,7 +9,11 @@ export async function startBackgroundImport() {
     let didProcess;
 
     try {
-      didProcess = await processQueueEntry();
+      // TODO: how should this be handled? This should handle all courses in parallell...
+      // one way would be to list all collections with a name standand, and process them all in parallell. But this would grow each time the app is used, and the collections are not removed. Can they be removed without input to the user is lost?
+     const collections = await listAllCollections();
+     Promise.all(collections.map((c)=> processQueueEntry(c.name)));
+
     } catch (err) {
       log.error({ err }, "Unexpected error when processing a Queue Entry");
     }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -16,6 +16,7 @@ const server = express();
 const COOKIE_MAX_AGE_SECONDS = 3600;
 const store = new MongoDBStore({
   uri: process.env.MONGODB_CONNECTION_STRING,
+  databaseName: "import-exams",
   collection: "sessions",
 
   // Session expiration time


### PR DESCRIPTION
This PR is a simple, stupid way to handle imports in parallell: instead of one queue for all Canvas rooms, it uses one queue (database collection) per Canvas room.