### PR TITLE
Fix VS Code complaining about ts config error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ globalConfig.json
 .vscode/settings.json
 node_modules
 .parcel-cache
+frontend/build

--- a/frontend/src/declarations.d.ts
+++ b/frontend/src/declarations.d.ts
@@ -1,0 +1,5 @@
+// declaration.d.ts
+declare module '*.scss' {
+  const content: Record<string, string>;
+  export default content;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -22,6 +22,8 @@
     /* Completeness */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */,
 
-    "jsx": "react"
+    "jsx": "react",
+
+    "moduleResolution": "nodenext",
   }
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -24,6 +24,8 @@
 
     "jsx": "react",
 
-    "moduleResolution": "nodenext",
+    // Fix module resolution
+    "module": "node16",
+    "moduleResolution": "node16",
   }
 }


### PR DESCRIPTION
This PR fixes VS Code complaining about module resolution and missing type declarations for .scss-files.

NOTE: This doesn't affect the ability to start the project since Parcel figured this stuff out during build.

In backend we use module resolution node10, but we don't use GOT in frontend so I set it to node16.
- node16 vs nodenext [ref](https://www.typescriptlang.org/docs/handbook/modules/reference.html#node16-nodenext-1)

I added declarations to allow scss-files with scss module support in VS Code:
- [ref](https://stackoverflow.com/a/41946697)