### PR TITLE
Use access token for parallell imports

### DIFF
--- a/backend/__test__/setupCourse.spec.ts
+++ b/backend/__test__/setupCourse.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, jest } from "@jest/globals";
 import { _throwIfNotExactlyOneLadokId } from "../src/api/endpointHandlers/setupCourse";
 import { EndpointError } from "../src/api/error";
 
+// TODO: this is now a class, should probably mock adminCanvasApiClient instead
 jest.mock("../src/api/externalApis/canvasApiClient");
 
 describe("setupCourse", () => {

--- a/backend/src/api/endpointHandlers/importQueueHandlers.ts
+++ b/backend/src/api/endpointHandlers/importQueueHandlers.ts
@@ -7,7 +7,7 @@ import {
   resetQueueForImport,
 } from "../importQueue";
 import { EndpointError } from "../error";
-import { enrollStudent } from "../externalApis/canvasApiClient";
+import canvasApi from "../externalApis/adminCanvasApiClient";
 import log from "skog";
 
 async function getStatusFromQueueHandler(req, res, next) {
@@ -124,12 +124,14 @@ async function fixErrorsInQueue(req, res, next) {
       if (entry.error?.type === "missing_student") {
         // Add student to Canvas
         // eslint-disable-next-line no-await-in-loop
-        await enrollStudent(courseId, entry.student.kthId).catch((err) => {
-          log.error(
-            { err },
-            `Error trying to add student [${entry.student.kthId}] in course [${courseId}]`
-          );
-        });
+        await canvasApi
+          .enrollStudent(courseId, entry.student.kthId)
+          .catch((err) => {
+            log.error(
+              { err },
+              `Error trying to add student [${entry.student.kthId}] in course [${courseId}]`
+            );
+          });
         // Add entry to the queue (since its already there, we update the status to "working")
       }
 

--- a/backend/src/api/endpointHandlers/importQueueHandlers.ts
+++ b/backend/src/api/endpointHandlers/importQueueHandlers.ts
@@ -54,6 +54,7 @@ async function addEntriesToQueue(req, res, next) {
         fileCreateDate: createDate,
         batchNo,
         fileName,
+        importStartedByUser: req.session.userId,
         status: "pending",
       }).catch((err) => {
         if (err?.type === "entry_exists") {

--- a/backend/src/api/endpointHandlers/listAllExams.ts
+++ b/backend/src/api/endpointHandlers/listAllExams.ts
@@ -1,6 +1,6 @@
 /** Functions that handle the "import exams" part of the app */
 import log from "skog";
-import * as canvasApi from "../externalApis/canvasApiClient";
+import canvasApi from "../externalApis/adminCanvasApiClient";
 import * as tentaApi from "../externalApis/tentaApiClient";
 import { getEntriesFromQueue } from "../importQueue";
 import { CanvasApiError, EndpointError } from "../error";

--- a/backend/src/api/endpointHandlers/setupCourse.ts
+++ b/backend/src/api/endpointHandlers/setupCourse.ts
@@ -1,6 +1,6 @@
 /** Endpoints to setup a Canvas course */
 
-import * as canvasApi from "../externalApis/canvasApiClient";
+import canvasApi from "../externalApis/adminCanvasApiClient";
 import { CanvasApiError, EndpointError } from "../error";
 import * as ladokApiClient from "../externalApis/ladokApiClient";
 

--- a/backend/src/api/externalApis/canvasApiClient.ts
+++ b/backend/src/api/externalApis/canvasApiClient.ts
@@ -16,16 +16,6 @@ import {
   propertiesToCreateSubmission,
 } from "../assignmentLock";
 
-let canvas: CanvasApi;
-if (process.env.NODE_ENV === "test") {
-  log.info("NOTE: Not instantiating canvas api since this is a test!");
-} else {
-  canvas = new CanvasApi(
-    process.env.CANVAS_API_URL,
-    process.env.CANVAS_API_ADMIN_TOKEN
-  );
-}
-
 /**
  * These endpoints have the content used as a template when creating the
  * homepage and assignment.
@@ -40,110 +30,416 @@ const TEMPLATES = {
     sv: "courses/33450/pages/151959",
   },
 };
+export default class CanvasApiClient {
+  canvas: CanvasApi;
+  constructor(url, token) {
+    this.canvas = new CanvasApi(url, token);
+  }
+  /** Get data from one canvas course */
 
-/** Get data from one canvas course */
-async function getCourse(courseId) {
-  const { body } = await canvas
-    .get<any>(`courses/${courseId}`)
-    .catch(canvasApiGenericErrorHandler);
+  async getCourse(courseId) {
+    const { body } = await this.canvas
+      .get<any>(`courses/${courseId}`)
+      .catch(canvasApiGenericErrorHandler);
 
-  return body;
-}
+    return body;
+  }
+  /** Creates a "good-looking" homepage in Canvas */
+  async createHomepage(courseId, language = "en") {
+    const { body: template } = await this.canvas
+      .get<any>(TEMPLATES.homepage[language])
+      .catch(canvasApiGenericErrorHandler);
 
-/** Creates a "good-looking" homepage in Canvas */
-async function createHomepage(courseId, language = "en") {
-  const { body: template } = await canvas
-    .get<any>(TEMPLATES.homepage[language])
-    .catch(canvasApiGenericErrorHandler);
+    await this.canvas
+      .request(`courses/${courseId}/front_page`, "PUT", {
+        wiki_page: {
+          // To make this page, use the Rich Content Editor in Canvas (https://kth.test.instructure.com/courses/30347/pages/welcome-to-the-exam/edit)
+          body: template.body,
+          title: template.title,
+        },
+      })
+      .catch(canvasApiGenericErrorHandler);
+    return this.canvas
+      .request(`courses/${courseId}`, "PUT", {
+        course: {
+          default_view: "wiki",
+        },
+      })
+      .catch(canvasApiGenericErrorHandler);
+  }
 
-  await canvas
-    .request(`courses/${courseId}/front_page`, "PUT", {
-      wiki_page: {
-        // To make this page, use the Rich Content Editor in Canvas (https://kth.test.instructure.com/courses/30347/pages/welcome-to-the-exam/edit)
-        body: template.body,
-        title: template.title,
-      },
-    })
-    .catch(canvasApiGenericErrorHandler);
-  return canvas
-    .request(`courses/${courseId}`, "PUT", {
-      course: {
-        default_view: "wiki",
-      },
-    })
-    .catch(canvasApiGenericErrorHandler);
-}
+  /** Publish a course */
+  async publishCourse(courseId) {
+    return this.canvas
+      .request(`courses/${courseId}`, "PUT", {
+        course: {
+          event: "offer",
+        },
+      })
+      .catch(canvasApiGenericErrorHandler);
+  }
 
-/** Publish a course */
-async function publishCourse(courseId) {
-  return canvas
-    .request(`courses/${courseId}`, "PUT", {
-      course: {
-        event: "offer",
-      },
-    })
-    .catch(canvasApiGenericErrorHandler);
-}
+  /** Get the Ladok UID of the examination linked with a canvas course */
+  async getAktivitetstillfalleUIDs(courseId) {
+    const sections = await this.canvas
+      .listItems<any>(`courses/${courseId}/sections`)
+      .toArray()
+      .catch(canvasApiGenericErrorHandler);
 
-/** Get the Ladok UID of the examination linked with a canvas course */
-async function getAktivitetstillfalleUIDs(courseId) {
-  const sections = await canvas
-    .listItems<any>(`courses/${courseId}/sections`)
-    .toArray()
-    .catch(canvasApiGenericErrorHandler);
+    // For SIS IDs with format "AKT.<ladok id>.<suffix>", take the "<ladok id>"
+    const REGEX = /^AKT\.([\w-]+)/;
+    const sisIds = sections
+      .map((section) => section.sis_section_id?.match(REGEX)?.[1])
+      .filter((sisId) => sisId /* Filter out null and undefined */);
 
-  // For SIS IDs with format "AKT.<ladok id>.<suffix>", take the "<ladok id>"
-  const REGEX = /^AKT\.([\w-]+)/;
-  const sisIds = sections
-    .map((section) => section.sis_section_id?.match(REGEX)?.[1])
-    .filter((sisId) => sisId /* Filter out null and undefined */);
+    // Deduplicate IDs (there are usually one "funka" and one "non-funka" with
+    // the same Ladok ID)
+    const uniqueIds = Array.from(new Set(sisIds));
 
-  // Deduplicate IDs (there are usually one "funka" and one "non-funka" with
-  // the same Ladok ID)
-  const uniqueIds = Array.from(new Set(sisIds));
+    return uniqueIds as string[];
+  }
 
-  return uniqueIds as string[];
-}
+  // TODO: this function is kept only for backwards-compatibility reasons
+  async getExaminationLadokId(courseId) {
+    const sections = await this.canvas
+      .listItems<any>(`courses/${courseId}/sections`)
+      .toArray()
+      .catch(canvasApiGenericErrorHandler);
 
-// TODO: this function is kept only for backwards-compatibility reasons
-async function getExaminationLadokId(courseId) {
-  const sections = await canvas
-    .listItems<any>(`courses/${courseId}/sections`)
-    .toArray()
-    .catch(canvasApiGenericErrorHandler);
+    // For SIS IDs with format "AKT.<ladok id>.<suffix>", take the "<ladok id>"
+    const REGEX = /^AKT\.([\w-]+)/;
+    const sisIds = sections
+      .map((section) => section.sis_section_id?.match(REGEX)?.[1])
+      .filter((sisId) => sisId /* Filter out null and undefined */);
 
-  // For SIS IDs with format "AKT.<ladok id>.<suffix>", take the "<ladok id>"
-  const REGEX = /^AKT\.([\w-]+)/;
-  const sisIds = sections
-    .map((section) => section.sis_section_id?.match(REGEX)?.[1])
-    .filter((sisId) => sisId /* Filter out null and undefined */);
+    // Deduplicate IDs (there are usually one "funka" and one "non-funka" with
+    // the same Ladok ID)
+    const uniqueIds = Array.from(new Set(sisIds));
 
-  // Deduplicate IDs (there are usually one "funka" and one "non-funka" with
-  // the same Ladok ID)
-  const uniqueIds = Array.from(new Set(sisIds));
+    // Right now we are not supporting rooms with more than one examination
+    if (uniqueIds.length !== 1) {
+      throw new Error(
+        `Course ${courseId} not supported: it is connected to ${uniqueIds.length} different Ladok Ids`
+      );
+    } else {
+      return uniqueIds[0] as string;
+    }
+  }
 
-  // Right now we are not supporting rooms with more than one examination
-  if (uniqueIds.length !== 1) {
-    throw new Error(
-      `Course ${courseId} not supported: it is connected to ${uniqueIds.length} different Ladok Ids`
+  async getValidAssignment(courseId, ladokId) {
+    const assignments = await this.canvas
+      .listItems<any>(`courses/${courseId}/assignments`)
+      .toArray()
+      .catch(canvasApiGenericErrorHandler);
+
+    // TODO: Filter more strictly?
+    return (
+      assignments.find((a) => a.integration_data?.ladokId === ladokId) ?? null
     );
-  } else {
-    return uniqueIds[0] as string;
+  }
+
+  async getAssignmentSubmissions(courseId, assignmentId) {
+    // API docs https://canvas.instructure.com/doc/api/submissions.html
+    // GET /api/v1/courses/:course_id/assignments/:assignment_id/submissions
+    // ?include=user (to get user obj wth kth id)
+    return this.canvas
+      .listItems<TSubmissionWithHistory>(
+        `courses/${courseId}/assignments/${assignmentId}/submissions`,
+        { include: ["user", "submission_history"] } // include user obj with kth id
+      )
+      .toArray()
+      .catch(canvasApiGenericErrorHandler);
+  }
+
+  async createAssignment(courseId, ladokId, language = "en") {
+    const examination = await getAktivitetstillfalle(ladokId);
+    const { body: template } = await this.canvas
+      .get<any>(TEMPLATES.assignment[language])
+      .catch(canvasApiGenericErrorHandler);
+
+    return this.canvas
+      .request(`courses/${courseId}/assignments`, "POST", {
+        assignment: {
+          ...propertiesToCreateLockedAssignment(examination.examDate),
+          name: template.name,
+          description: template.description,
+          integration_data: {
+            ladokId,
+          },
+          anonymous_grading: !!examination.anonymous, // convert to boolean if undefined
+          published: false,
+          grading_type: "letter_grade",
+          notify_of_update: false,
+          // TODO: take the grading standard from TentaAPI
+          //       grading_standard_id: 1,
+        },
+      })
+      .then((r) => r.body as any)
+      .catch(canvasApiGenericErrorHandler);
+  }
+
+  /** Publish an assignment */
+  async publishAssignment(courseId, assignmentId) {
+    return this.canvas
+      .request(`courses/${courseId}/assignments/${assignmentId}`, "PUT", {
+        assignment: {
+          published: true,
+        },
+      })
+      .catch(canvasApiGenericErrorHandler);
+  }
+
+  /**
+   * Allows the app to upload exams.
+   */
+  async unlockAssignment(courseId, assignmentId) {
+    return this.canvas
+      .request(`courses/${courseId}/assignments/${assignmentId}`, "PUT", {
+        assignment: {
+          ...propertiesToUnlockAssignment(),
+          published: true,
+        },
+      })
+      .catch(canvasApiGenericErrorHandler);
+  }
+
+  /**
+   * Prevents students to upload things by accident.
+   */
+  async lockAssignment(courseId, assignmentId) {
+    return this.canvas
+      .request(`courses/${courseId}/assignments/${assignmentId}`, "PUT", {
+        assignment: {
+          ...propertiesToLockAssignment(),
+        },
+      })
+      .catch(canvasApiGenericErrorHandler);
+  }
+
+  uploadFileErrorHandler(err): never {
+    Error.captureStackTrace(err, this.uploadFileErrorHandler);
+
+    throw new FileUploadError({
+      type: "unhandled_error",
+      message: "Error uploading file to storage",
+      err,
+    });
+  }
+
+  // eslint-disable-next-line camelcase
+  async sendFile({ upload_url, upload_params }, content) {
+    const form = new FormData();
+
+    // eslint-disable-next-line camelcase
+    for (const key in upload_params) {
+      if (upload_params[key]) {
+        form.append(key, upload_params[key]);
+      }
+    }
+
+    form.append("attachment", content, upload_params.filename);
+
+    return got
+      .post<any>({
+        url: upload_url,
+        body: form.stream,
+        headers: form.headers,
+        responseType: "json",
+      })
+      .catch(this.uploadFileErrorHandler);
+  }
+
+  // TODO: Refactor this function and uploadExam to avoid requesting the endpoint
+  //       "GET users/sis_user_id:${userId}" twice
+  async hasSubmission({ courseId, assignmentId, userId }) {
+    try {
+      const { body: user } = await this.canvas
+        .get<any>(`users/sis_user_id:${userId}`)
+        .catch(canvasApiGenericErrorHandler);
+      const { body: submission } = await this.canvas
+        .get<any>(
+          `courses/${courseId}/assignments/${assignmentId}/submissions/${user.id}`
+        )
+        .catch(canvasApiGenericErrorHandler);
+
+      return !submission.missing;
+    } catch (err) {
+      if (err.response?.statusCode === 404) {
+        return false;
+      }
+      throw err;
+    }
+  }
+
+  async uploadExam(content, { courseId, studentKthId, examDate, fileId }) {
+    try {
+      const { body: user } = await this.canvas
+        .get<any>(`users/sis_user_id:${studentKthId}`)
+        .catch(canvasApiGenericErrorHandler);
+
+      const ladokId = await this.getExaminationLadokId(courseId);
+      const assignment = await this.getValidAssignment(courseId, ladokId);
+      log.debug(
+        `Upload Exam: unlocking assignment ${assignment.id} in course ${courseId}`
+      );
+
+      const reqTokenStart = Date.now();
+      // TODO: will return a 400 if the course is unpublished
+      const { body: slot } = await this.canvas
+        .request<any>(
+          `courses/${courseId}/assignments/${assignment.id}/submissions/${user.id}/files`,
+          "POST",
+          {
+            name: `${fileId}.pdf`,
+          }
+        )
+        .catch((err): never => {
+          if (err.response?.statusCode === 404) {
+            // Student is missing in Canvas, we can fix this
+            throw new ImportError({
+              type: "missing_student",
+              message: "Student is missing in examroom",
+              details: {
+                kthId: studentKthId,
+              },
+            });
+          } else {
+            // Other errors from Canvas API that we don't know how to fix
+            throw new ImportError({
+              type: "import_error",
+              message: `Canvas returned an error when importing this exam (windream fileId: ${fileId})`,
+              details: {
+                kthId: studentKthId,
+                fileId,
+              },
+            });
+          }
+        });
+
+      log.debug(
+        "Time to generate upload token: " + (Date.now() - reqTokenStart) + "ms"
+      );
+
+      const uploadFileStart = Date.now();
+      const { body: uploadedFile } = await this.sendFile(slot, content);
+
+      log.debug(
+        "Time to upload file: " + (Date.now() - uploadFileStart) + "ms"
+      );
+
+      // TODO: move the following statement outside of this function
+      // Reason: this module (canvasApiClient) should not contain "business rules"
+      await this.unlockAssignment(courseId, assignment.id);
+
+      // Get existing submission history for this student and assignment to figure out
+      // timestamp offset. If we submit on the same timestamp (submitted_at), the old
+      // submission gets overwritten.
+      const { body: submission } = await this.getAssignmentSubmissionForStudent(
+        {
+          courseId,
+          assignmentId: assignment.id,
+          userId: user.id,
+        }
+      );
+
+      // There is always a submission to start with in the history with status "unsubmitted"
+      // so we need to filter that out when getting nrof actual submissions
+      const nrofSubmissions =
+        submission.submission_history?.filter(
+          (s) => s.workflow_state !== "unsubmitted"
+        ).length ?? 0;
+      const submissionProps = propertiesToCreateSubmission(
+        examDate,
+        nrofSubmissions
+      );
+      const { submitted_at } = submissionProps;
+
+      await this.canvas
+        .request(
+          `courses/${courseId}/assignments/${assignment.id}/submissions/`,
+          "POST",
+          {
+            submission: {
+              ...submissionProps,
+              submission_type: "online_upload",
+              user_id: user.id,
+              file_ids: [uploadedFile.id],
+            },
+          }
+        )
+        .catch(canvasApiGenericErrorHandler);
+
+      return submitted_at;
+    } catch (err) {
+      if (err.type === "missing_student") {
+        log.warn(
+          `User ${studentKthId} is missing in Canvas course ${courseId}`
+        );
+      } else if (!studentKthId) {
+        log.warn(
+          `User is missing KTH ID, needs du be manually graded: Windream fileid ${fileId} / course ${courseId}`
+        );
+      } else {
+        log.error(
+          { err },
+          `Error when uploading exam: KTH ID ${studentKthId} / course ${courseId}`
+        );
+      }
+      throw err;
+    }
+  }
+
+  // TOOD: This function can take very long to run. Consider changing it somehow
+  async getRoles(courseId, userId) {
+    if (!courseId) {
+      throw new EndpointError({
+        type: "missing_argument",
+        statusCode: 400,
+        message: "Missing argument [courseId]",
+      });
+    }
+
+    if (!userId) {
+      throw new EndpointError({
+        type: "missing_argument",
+        statusCode: 400,
+        message: "Missing argument [userId]",
+      });
+    }
+
+    // TODO: error handling for non-existent courseId or userId
+    const enrollments = await this.canvas
+      .listItems<any>(`courses/${courseId}/enrollments`, { per_page: 100 })
+      .toArray()
+      .catch(canvasApiGenericErrorHandler);
+
+    return enrollments
+      .filter((enr) => enr.user_id === userId)
+      .map((enr) => enr.role_id);
+  }
+
+  async getAssignmentSubmissionForStudent({ courseId, assignmentId, userId }) {
+    return this.canvas
+      .get<{ submission_history: { workflow_state: string }[] }>(
+        `courses/${courseId}/assignments/${assignmentId}/submissions/${userId}`,
+        { include: ["submission_history"] }
+      )
+      .catch(canvasApiGenericErrorHandler);
+  }
+
+  async enrollStudent(courseId, userId) {
+    return this.canvas
+      .request(`courses/${courseId}/enrollments`, "POST", {
+        enrollment: {
+          user_id: `sis_user_id:${userId}`,
+          role_id: 3,
+          enrollment_state: "active",
+          notify: false,
+        },
+      })
+      .catch(canvasApiGenericErrorHandler);
   }
 }
-
-async function getValidAssignment(courseId, ladokId) {
-  const assignments = await canvas
-    .listItems<any>(`courses/${courseId}/assignments`)
-    .toArray()
-    .catch(canvasApiGenericErrorHandler);
-
-  // TODO: Filter more strictly?
-  return (
-    assignments.find((a) => a.integration_data?.ladokId === ladokId) ?? null
-  );
-}
-
 type TSubmissionWithHistory = {
   submission_history: {
     attachments: {
@@ -153,324 +449,4 @@ type TSubmissionWithHistory = {
   user: {
     sis_user_id: string;
   };
-};
-
-async function getAssignmentSubmissions(courseId, assignmentId) {
-  // API docs https://canvas.instructure.com/doc/api/submissions.html
-  // GET /api/v1/courses/:course_id/assignments/:assignment_id/submissions
-  // ?include=user (to get user obj wth kth id)
-  return canvas
-    .listItems<TSubmissionWithHistory>(
-      `courses/${courseId}/assignments/${assignmentId}/submissions`,
-      { include: ["user", "submission_history"] } // include user obj with kth id
-    )
-    .toArray()
-    .catch(canvasApiGenericErrorHandler);
-}
-
-async function createAssignment(courseId, ladokId, language = "en") {
-  const examination = await getAktivitetstillfalle(ladokId);
-  const { body: template } = await canvas
-    .get<any>(TEMPLATES.assignment[language])
-    .catch(canvasApiGenericErrorHandler);
-
-  return canvas
-    .request(`courses/${courseId}/assignments`, "POST", {
-      assignment: {
-        ...propertiesToCreateLockedAssignment(examination.examDate),
-        name: template.name,
-        description: template.description,
-        integration_data: {
-          ladokId,
-        },
-        anonymous_grading: !!examination.anonymous, // convert to boolean if undefined
-        published: false,
-        grading_type: "letter_grade",
-        notify_of_update: false,
-        // TODO: take the grading standard from TentaAPI
-        //       grading_standard_id: 1,
-      },
-    })
-    .then((r) => r.body as any)
-    .catch(canvasApiGenericErrorHandler);
-}
-
-/** Publish an assignment */
-async function publishAssignment(courseId, assignmentId) {
-  return canvas
-    .request(`courses/${courseId}/assignments/${assignmentId}`, "PUT", {
-      assignment: {
-        published: true,
-      },
-    })
-    .catch(canvasApiGenericErrorHandler);
-}
-
-/**
- * Allows the app to upload exams.
- */
-async function unlockAssignment(courseId, assignmentId) {
-  return canvas
-    .request(`courses/${courseId}/assignments/${assignmentId}`, "PUT", {
-      assignment: {
-        ...propertiesToUnlockAssignment(),
-        published: true,
-      },
-    })
-    .catch(canvasApiGenericErrorHandler);
-}
-
-/**
- * Prevents students to upload things by accident.
- */
-async function lockAssignment(courseId, assignmentId) {
-  return canvas
-    .request(`courses/${courseId}/assignments/${assignmentId}`, "PUT", {
-      assignment: {
-        ...propertiesToLockAssignment(),
-      },
-    })
-    .catch(canvasApiGenericErrorHandler);
-}
-
-function uploadFileErrorHandler(err): never {
-  Error.captureStackTrace(err, uploadFileErrorHandler);
-
-  throw new FileUploadError({
-    type: "unhandled_error",
-    message: "Error uploading file to storage",
-    err,
-  });
-}
-
-// eslint-disable-next-line camelcase
-async function sendFile({ upload_url, upload_params }, content) {
-  const form = new FormData();
-
-  // eslint-disable-next-line camelcase
-  for (const key in upload_params) {
-    if (upload_params[key]) {
-      form.append(key, upload_params[key]);
-    }
-  }
-
-  form.append("attachment", content, upload_params.filename);
-
-  return got
-    .post<any>({
-      url: upload_url,
-      body: form.stream,
-      headers: form.headers,
-      responseType: "json",
-    })
-    .catch(uploadFileErrorHandler);
-}
-
-// TODO: Refactor this function and uploadExam to avoid requesting the endpoint
-//       "GET users/sis_user_id:${userId}" twice
-async function hasSubmission({ courseId, assignmentId, userId }) {
-  try {
-    const { body: user } = await canvas
-      .get<any>(`users/sis_user_id:${userId}`)
-      .catch(canvasApiGenericErrorHandler);
-    const { body: submission } = await canvas
-      .get<any>(
-        `courses/${courseId}/assignments/${assignmentId}/submissions/${user.id}`
-      )
-      .catch(canvasApiGenericErrorHandler);
-
-    return !submission.missing;
-  } catch (err) {
-    if (err.response?.statusCode === 404) {
-      return false;
-    }
-    throw err;
-  }
-}
-
-async function uploadExam(
-  content,
-  { courseId, studentKthId, examDate, fileId }
-) {
-  try {
-    const { body: user } = await canvas
-      .get<any>(`users/sis_user_id:${studentKthId}`)
-      .catch(canvasApiGenericErrorHandler);
-
-    const ladokId = await getExaminationLadokId(courseId);
-    const assignment = await getValidAssignment(courseId, ladokId);
-    log.debug(
-      `Upload Exam: unlocking assignment ${assignment.id} in course ${courseId}`
-    );
-
-    const reqTokenStart = Date.now();
-    // TODO: will return a 400 if the course is unpublished
-    const { body: slot } = await canvas
-      .request<any>(
-        `courses/${courseId}/assignments/${assignment.id}/submissions/${user.id}/files`,
-        "POST",
-        {
-          name: `${fileId}.pdf`,
-        }
-      )
-      .catch((err): never => {
-        if (err.response?.statusCode === 404) {
-          // Student is missing in Canvas, we can fix this
-          throw new ImportError({
-            type: "missing_student",
-            message: "Student is missing in examroom",
-            details: {
-              kthId: studentKthId,
-            },
-          });
-        } else {
-          // Other errors from Canvas API that we don't know how to fix
-          throw new ImportError({
-            type: "import_error",
-            message: `Canvas returned an error when importing this exam (windream fileId: ${fileId})`,
-            details: {
-              kthId: studentKthId,
-              fileId,
-            },
-          });
-        }
-      });
-
-    log.debug(
-      "Time to generate upload token: " + (Date.now() - reqTokenStart) + "ms"
-    );
-
-    const uploadFileStart = Date.now();
-    const { body: uploadedFile } = await sendFile(slot, content);
-
-    log.debug("Time to upload file: " + (Date.now() - uploadFileStart) + "ms");
-
-    // TODO: move the following statement outside of this function
-    // Reason: this module (canvasApiClient) should not contain "business rules"
-    await unlockAssignment(courseId, assignment.id);
-
-    // Get existing submission history for this student and assignment to figure out
-    // timestamp offset. If we submit on the same timestamp (submitted_at), the old
-    // submission gets overwritten.
-    const { body: submission } = await getAssignmentSubmissionForStudent({
-      courseId,
-      assignmentId: assignment.id,
-      userId: user.id,
-    });
-
-    // There is always a submission to start with in the history with status "unsubmitted"
-    // so we need to filter that out when getting nrof actual submissions
-    const nrofSubmissions =
-      submission.submission_history?.filter(
-        (s) => s.workflow_state !== "unsubmitted"
-      ).length ?? 0;
-    const submissionProps = propertiesToCreateSubmission(
-      examDate,
-      nrofSubmissions
-    );
-    const { submitted_at } = submissionProps;
-
-    await canvas
-      .request(
-        `courses/${courseId}/assignments/${assignment.id}/submissions/`,
-        "POST",
-        {
-          submission: {
-            ...submissionProps,
-            submission_type: "online_upload",
-            user_id: user.id,
-            file_ids: [uploadedFile.id],
-          },
-        }
-      )
-      .catch(canvasApiGenericErrorHandler);
-
-    return submitted_at;
-  } catch (err) {
-    if (err.type === "missing_student") {
-      log.warn(`User ${studentKthId} is missing in Canvas course ${courseId}`);
-    } else if (!studentKthId) {
-      log.warn(
-        `User is missing KTH ID, needs du be manually graded: Windream fileid ${fileId} / course ${courseId}`
-      );
-    } else {
-      log.error(
-        { err },
-        `Error when uploading exam: KTH ID ${studentKthId} / course ${courseId}`
-      );
-    }
-    throw err;
-  }
-}
-
-// TOOD: This function can take very long to run. Consider changing it somehow
-async function getRoles(courseId, userId) {
-  if (!courseId) {
-    throw new EndpointError({
-      type: "missing_argument",
-      statusCode: 400,
-      message: "Missing argument [courseId]",
-    });
-  }
-
-  if (!userId) {
-    throw new EndpointError({
-      type: "missing_argument",
-      statusCode: 400,
-      message: "Missing argument [userId]",
-    });
-  }
-
-  // TODO: error handling for non-existent courseId or userId
-  const enrollments = await canvas
-    .listItems<any>(`courses/${courseId}/enrollments`, { per_page: 100 })
-    .toArray()
-    .catch(canvasApiGenericErrorHandler);
-
-  return enrollments
-    .filter((enr) => enr.user_id === userId)
-    .map((enr) => enr.role_id);
-}
-
-async function getAssignmentSubmissionForStudent({
-  courseId,
-  assignmentId,
-  userId,
-}) {
-  return canvas
-    .get<{ submission_history: { workflow_state: string }[] }>(
-      `courses/${courseId}/assignments/${assignmentId}/submissions/${userId}`,
-      { include: ["submission_history"] }
-    )
-    .catch(canvasApiGenericErrorHandler);
-}
-
-async function enrollStudent(courseId, userId) {
-  return canvas
-    .request(`courses/${courseId}/enrollments`, "POST", {
-      enrollment: {
-        user_id: `sis_user_id:${userId}`,
-        role_id: 3,
-        enrollment_state: "active",
-        notify: false,
-      },
-    })
-    .catch(canvasApiGenericErrorHandler);
-}
-
-export {
-  getCourse,
-  publishCourse,
-  createHomepage,
-  getAktivitetstillfalleUIDs,
-  getValidAssignment,
-  getAssignmentSubmissions,
-  createAssignment,
-  publishAssignment,
-  unlockAssignment,
-  lockAssignment,
-  hasSubmission,
-  uploadExam,
-  getRoles,
-  enrollStudent,
 };

--- a/backend/src/api/importQueue/index.ts
+++ b/backend/src/api/importQueue/index.ts
@@ -29,6 +29,12 @@ async function getImportQueueCollection() {
   return databaseClient.db("import-exams").collection(DB_QUEUE_NAME);
 }
 
+export async function getSessionCollection() {
+  await connectToDatabase();
+
+  return databaseClient.db("import-exams").collection("sessions");
+}
+
 /**
  * For runtime input param testing
  * @param {bool|function} test Test case that should return true

--- a/backend/src/api/importQueue/index.ts
+++ b/backend/src/api/importQueue/index.ts
@@ -470,7 +470,9 @@ async function updateStatusOfEntryInQueue(
   }
 }
 
-export async function getFirstPendingPerCourseFromQueue() {
+export async function getFirstPendingPerCourseFromQueue(): Promise<
+  QueueEntry[]
+> {
   try {
     const collImportQueue = await getImportQueueCollection();
     const aggCursor = collImportQueue.aggregate([
@@ -487,8 +489,14 @@ export async function getFirstPendingPerCourseFromQueue() {
       },
     ]);
     const result = [];
-    for await (const doc of aggCursor) {
-      result.push(doc);
+    for await (const aggData of aggCursor) {
+      const entry = new QueueEntry({
+        courseId: aggData._id.courseId,
+        fileId: aggData.fileId,
+        status: aggData._id.status,
+        importStartedByUser: aggData._id.importStartedByUser,
+      } as any);
+      result.push(entry);
     }
     return result;
   } catch (err) {

--- a/backend/src/api/importQueue/processQueueEntry.ts
+++ b/backend/src/api/importQueue/processQueueEntry.ts
@@ -5,6 +5,7 @@ import {
   getFirstPendingFromQueue,
   updateStatusOfEntryInQueue,
   updateStudentOfEntryInQueue,
+  getFirstPendingPerCourseFromQueue,
 } from "./index";
 import { ImportError } from "../error";
 
@@ -107,6 +108,11 @@ function handleUploadErrors(err, exam) {
   }
 }
 
+export async function processOneEntryPerExamRoom() {
+  const firstExamPerRoom = await getFirstPendingPerCourseFromQueue();
+  console.log("pending:", firstExamPerRoom);
+}
+
 /**
  * Find and process an entry from the global import queue and exit
  * @returns {bool} return true is entry was processed and false if queue was empty
@@ -117,12 +123,6 @@ export async function processQueueEntry() {
   if (examToBeImported) {
     // Log the courseId for this operation
     try {
-      // Force errors during development
-      if (IS_DEV && FORCE_RANDOM_ERRORS) {
-        if (Math.random() > 0.8)
-          throw Error("Forced error for testing during development");
-      }
-
       // Upload to Canvas
       await log
         .child({ courseId: examToBeImported?.courseId }, () =>

--- a/backend/src/api/importQueue/processQueueEntry.ts
+++ b/backend/src/api/importQueue/processQueueEntry.ts
@@ -1,5 +1,5 @@
 import log from "skog";
-import * as canvasApi from "../externalApis/canvasApiClient";
+import canvasApi from "../externalApis/adminCanvasApiClient";
 import * as tentaApi from "../externalApis/tentaApiClient";
 import {
   getFirstPendingFromQueue,
@@ -110,6 +110,12 @@ function handleUploadErrors(err, exam) {
 
 export async function processOneEntryPerExamRoom() {
   const firstExamPerRoom = await getFirstPendingPerCourseFromQueue();
+  Promise.all(
+    firstExamPerRoom.map((entry) => {
+      // TODO: how to construct a temporary canvasApi object?
+      const _canvasApi = canvasApi;
+    })
+  );
   console.log("pending:", firstExamPerRoom);
 }
 

--- a/backend/src/importWorker.ts
+++ b/backend/src/importWorker.ts
@@ -1,18 +1,29 @@
 /* eslint-disable no-await-in-loop */
 import log from "skog";
-import { processQueueEntry } from "./api/importQueue/processQueueEntry";
+import {
+  processQueueEntry,
+  processOneEntryPerExamRoom,
+} from "./api/importQueue/processQueueEntry";
 
 export async function startBackgroundImport() {
   log.info("Start background import");
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    let didProcess;
+    let didProcessOne, didProcessMultiple;
 
     try {
-      didProcess = await processQueueEntry();
+      // Process one entry per exam room in the queue, by the logged in user
+      // TODO
+      didProcessMultiple = await processOneEntryPerExamRoom();
+      // Process one entry from the queue, by the admin user
+      // This is needed because the access tokens for each user might expire. This first call makes sure that
+      // exam rooms with many exams are processed eventually.
+      didProcessOne = await processQueueEntry();
     } catch (err) {
       log.error({ err }, "Unexpected error when processing a Queue Entry");
     }
-    await new Promise((resolve) => setTimeout(resolve, didProcess ? 10 : 1000));
+    await new Promise((resolve) =>
+      setTimeout(resolve, didProcessOne ? 10 : 1000)
+    );
   }
 }


### PR DESCRIPTION
This is another draft at uploading exams in parallell.
This both uses the admin token, and each users tokens to upload exams. The reason for doing both is that the user tokens might expire before the import is finished. 